### PR TITLE
IE8 Баг с событием window.resize

### DIFF
--- a/common.blocks/i-bem/__dom/i-bem__dom.js
+++ b/common.blocks/i-bem/__dom/i-bem__dom.js
@@ -414,6 +414,25 @@ var DOM = BEM.DOM = BEM.decl('i-bem__dom',/** @lends BEM.DOM.prototype */{
      * @returns {BEM}
      */
     bindToWin : function(event, fn) {
+        var _fn = fn,
+            currentHeight,
+            currentWidth,
+            win;
+
+        if (event === 'resize') {
+            win = this.__self.win;
+            fn = function() {
+                var height = win.height(),
+                    width = win.width();
+
+                if (currentHeight !== height || currentWidth !== width) {
+                    currentHeight = height;
+                    currentWidth = width;
+                    _fn.apply(this, arguments);
+                }
+            }
+        }
+        
         this._needSpecialUnbind = true;
         return this.bindToDomElem(win, event, fn);
     },


### PR DESCRIPTION
IE8 триггерит resize окна при изменении размеров любого элемента, иногда это может привести к неожиданным результатам
http://cyanbyfuchsia.wordpress.com/2012/06/20/window-resize-and-internet-explorer-8/
