### PR TITLE
BEMHTML: Generate final .bemhtml.js with `modules.define`

### DIFF
--- a/.bem/lib/bemhtml/api.js
+++ b/.bem/lib/bemhtml/api.js
@@ -25,6 +25,8 @@ api.translate = function translate(source, options) {
          '  })({});',
          '  if(typeof exports === "object") {',
          '    exports["' + exportName + '"] = __xjst;',
+         '  } else if(typeof modules === "object") {',
+         '    modules.define("' + exportName + '", function(provide) { provide(__xjst) });',
          '  } else {',
          '    g["' + exportName + '"] = __xjst;',
          '  }',


### PR DESCRIPTION
We can drop `BEMHMTL` from   global scope and use modules system.
