### PR TITLE
use v2 technologies all over the place

### DIFF
--- a/.bem/levels/blocks.js
+++ b/.bem/levels/blocks.js
@@ -7,12 +7,12 @@ var PATH = require('path'),
 
 exports.getTechs = function() {
     var techs = {
-        'bemjson.js' : '',
-        'bemdecl.js' : 'bemdecl.js',
-        'deps.js'    : 'deps.js',
-        'css'        : 'css',
-        'ie.css'     : 'ie.css',
-        'js'         : 'js-i'
+        'bemjson.js'                 : '',
+        'bemdecl.js'                 : 'v2/bemdecl.js',
+        'deps.js'                    : 'v2/deps.js',
+        'css'                        : 'v2/css',
+        'ie.css'                     : 'v2/ie.css',
+        'js'                         : 'v2/js-i'
     };
 
     [

--- a/.bem/techs/bemhtml.js
+++ b/.bem/techs/bemhtml.js
@@ -3,11 +3,8 @@ var BEM = require('bem'),
     PATH = require('path'),
     compat = require('bemhtml-compat'),
 
-    Tech = require('bem/lib/tech').TechV2;
-
-exports.baseTech = Tech;
-
 exports.techMixin = {
+    API_VER:2,
 
     getBuildSuffixesMap: function() {
         return {

--- a/.bem/techs/bemhtml.js
+++ b/.bem/techs/bemhtml.js
@@ -1,16 +1,18 @@
 var BEM = require('bem'),
     Q = BEM.require('q'),
     PATH = require('path'),
-    compat = require('bemhtml-compat');
+    compat = require('bemhtml-compat'),
+
+    Tech = require('bem/lib/tech').TechV2;
+
+exports.baseTech = Tech;
 
 exports.techMixin = {
 
-    getSuffixes : function() {
-        return ['bemhtml', 'bemhtml.xjst'];
-    },
-
-    getBuildSuffixes : function() {
-        return ['bemhtml.js'];
+    getBuildSuffixesMap: function() {
+        return {
+            'bemhtml.js': ['bemhtml', 'bemhtml.xjst']
+        };
     },
 
     getCreateSuffixes : function() {
@@ -20,24 +22,18 @@ exports.techMixin = {
     getBuildResultChunk : function(relPath, path, suffix) {
         var content = this.readContent(path, suffix);
         return (suffix !== 'bemhtml.xjst' ?
-            content.then(function(source) { return compat.transpile(source) }) :
+            content.then(function(source) { return compat.transpile(source); }) :
             content)
                 .then(function(source) {
                     return '\n/* begin: ' + relPath + ' */\n' +
                         source +
                         '\n/* end: ' + relPath + ' */\n';
-                })
+                });
     },
 
-    getBuildResult : function(prefixes, suffix, outputDir, outputName) {
+    getBuildResult : function(files, suffix, output, opts) {
         var _t = this;
-        return this.filterPrefixes(prefixes, this.getCreateSuffixes())
-            .then(function(paths) {
-                return Q.all(paths.map(function(path) {
-                    return _t.getBuildResultChunk(
-                            PATH.relative(outputDir, path), path, suffix);
-                }));
-            })
+        return this.__base(files, suffix, output, opts)
             .then(_t.getCompiledResult.bind(_t));
     },
 

--- a/.bem/techs/bemhtml.js
+++ b/.bem/techs/bemhtml.js
@@ -1,7 +1,7 @@
 var BEM = require('bem'),
     Q = BEM.require('q'),
     PATH = require('path'),
-    compat = require('bemhtml-compat'),
+    compat = require('bemhtml-compat');
 
 exports.techMixin = {
     API_VER:2,

--- a/.bem/techs/bemtree.js
+++ b/.bem/techs/bemtree.js
@@ -2,16 +2,14 @@ exports.baseTechPath = require.resolve('./bemhtml.js');
 
 exports.techMixin = {
 
-    getSuffixes : function() {
-        return ['bemtree'];
+    getBuildSuffixesMap: function() {
+        return {
+            'bemtree.js': ['bemtree']
+        };
     },
 
     getCreateSuffixes : function() {
         return ['bemtree'];
-    },
-
-    getBuildSuffixes : function() {
-        return ['bemtree.js'];
     },
 
     getCompiledResult : function(sources) {

--- a/.bem/techs/browser.js+bemhtml.js
+++ b/.bem/techs/browser.js+bemhtml.js
@@ -1,70 +1,64 @@
-var PATH = require('path');
+var BEM = require('bem'),
+    Q = BEM.require('q');
 
 exports.baseTechName = 'browser.js';
 
 exports.techMixin = {
 
-    /**
-     * Build and return result of build of specified prefixes
-     * for specified suffix.
-     *
-     * @param {Promise * String[]} prefixes Prefixes to build from.
-     * @param {String} suffix Suffix to build result for.
-     * @param {String} outputDir Output dir name for build result.
-     * @param {String} outputName Output name of build result.
-     * @returns {Promise * String} Promise for build result.
-     */
-    getBuildResult: function(prefixes, suffix, outputDir, outputName) {
+    getBuildResults: function(decl, levels, output, opts) {
+        var _this = this;
 
-        var context = this.context,
-            opts = context.opts;
-
-        return this.__base(prefixes, suffix, outputDir, outputName)
+        return this.__base(decl, levels, output, opts)
             .then(function(res) {
 
-                return opts.declaration
-                    .then(function(decl) {
+                return _this.concatBemhtml(res, output, opts)
+                    .then(function() {
+                        return res;
+                    });
 
-                        decl = decl.depsByTechs;
+            });
+    },
 
-                        // do nothing if decl.depsByTechs.js.bemhtml doesn't exists
-                        if (!decl || !decl.js || !decl.js.bemhtml) return res;
+    concatBemhtml: function(res, output, opts) {
+        var _this = this,
+            context = this.context,
+            declaration = context.opts.declaration;
 
-                        // js+bemhtml decl
-                        decl = { deps: decl.js.bemhtml };
+        return declaration
+            .then(function(decl) {
 
-                        var bemhtmlTech = context.createTech('bemhtml'),
-                            output = PATH.resolve(
-                                opts.outputDir,
-                                opts.outputName
-                            ),
-                            // get `.js` build prefixes
-                            prefixes = bemhtmlTech.getBuildPrefixes(
-                                bemhtmlTech.transformBuildDecl(decl),
-                                context.getLevels()
-                            ),
-                            // and build bemhtml based on them
-                            bemhtmlResults = bemhtmlTech.getBuildResults(
-                                prefixes,
-                                PATH.dirname(output) + PATH.dirSep,
-                                PATH.basename(output)
-                            );
+                decl = decl.depsByTechs;
 
-                        return bemhtmlResults
-                            .then(function(r) {
+                if (!decl || !decl.js || !decl.js.bemhtml) return;
 
-                                // put bemhtml templates at the top of builded js file
-                                res.push(r['bemhtml.js']);
+                decl = { deps: decl.js.bemhtml };
 
-                                // and return new result
-                                return res;
+                var bemhtmlTech = context.createTech('bemhtml');
 
-                            });
+                if (bemhtmlTech.API_VER !== 2) return Q.reject(new Error(_this.getTechName() +
+                    ' can’t use v1 bemhtml tech to concat bemhtml content. Configure level to use v2 bemhtml.'));
+
+                var bemhtmlResults = bemhtmlTech.getBuildResults(
+                        decl,
+                        context.getLevels(),
+                        output,
+                        opts
+                    );
+
+                return bemhtmlResults
+                    .then(function(r) {
+
+                        // put bemhtml templates at the top of builded js file
+                        Object.keys(res).forEach(function(suffix) {
+                            // test for array as in i18n.js+bemhtml tech
+                            // there's hack to create symlink for default lang
+                            // so 'js' key is a string there
+                            Array.isArray(res[suffix]) && res[suffix].unshift(r['bemhtml.js']);
+                        });
 
                     });
 
             });
-
     }
 
 };

--- a/.bem/techs/browser.js.js
+++ b/.bem/techs/browser.js.js
@@ -25,14 +25,15 @@ exports.techMixin = {
         };
     },
 
-    getYmChunk : function(outputDir, outputName, suffix) {
-        var ymRelPath = PATH.relative(outputDir, ymPath);
+    getYmChunk : function(output) {
+        var outputDir = PATH.resolve(output, '..'),
+            ymRelPath = PATH.relative(outputDir, ymPath);
         return this.getBuildResultChunk(ymRelPath, ymPath);
     },
 
-    getBuildResult : function(prefixes, suffix, outputDir, outputName) {
+    getBuildResult : function(files, suffix, output, opts) {
         return Q.all([
-                this.getYmChunk(outputDir, outputName, suffix),
+                this.getYmChunk(output),
                 this.__base.apply(this, arguments)
             ])
             .spread(function(ym, res) {

--- a/.bem/techs/node.js.js
+++ b/.bem/techs/node.js.js
@@ -20,7 +20,7 @@ exports.techMixin = {
         };
     },
 
-    getYmChunk : function(outputDir, outputName, suffix) {
+    getYmChunk : function() {
         return [
             "if(typeof module !== 'undefined') {",
             "modules = require('ym');",
@@ -28,7 +28,7 @@ exports.techMixin = {
         ].join('');
     },
 
-    getBuildResult : function(prefixes, suffix, outputDir, outputName) {
+    getBuildResult : function(files, suffix, output, opts) {
         var ymChunk = this.getYmChunk();
         return this.__base.apply(this, arguments)
             .then(function(res) {

--- a/.bem/techs/vanilla.js.js
+++ b/.bem/techs/vanilla.js.js
@@ -41,18 +41,6 @@ exports.techMixin = {
             "});",
             ""
         ], vars);
-    },
-
-    getBuildResult : function(prefixes, suffix, outputDir, outputName) {
-        var _t = this;
-        return Q.when(
-                this.filterPrefixes(prefixes, this.getBuildSuffixesMap()[suffix] || [suffix]),
-                function(paths) {
-                    return Q.all(paths.map(function(path) {
-                        return _t.getBuildResultChunk(
-                            PATH.relative(outputDir, path), path, suffix);
-                    }));
-                });
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bem-environ": "~1.2.0"
   },
   "devDependencies": {
-    "bem": "~0.5.29",
+    "bem": "0.6.x",
     "mocha": "~1.9.0",
     "jshint": "2.1.8",
     "jshint-groups": "0.5.1",


### PR DESCRIPTION
This is the rebased version of https://github.com/bem/bem-core/pull/142, which now invalidates targets right due to technologies metadata cache fix in bem-tools 0.6.11.
With https://github.com/narqo/bem-pr/pull/40 it seems to build test bundles (sets target) ok.
