### PR TITLE
"node.js" tech should use `require()` for chunks inclusion

### DIFF
--- a/.bem/techs/browser.js.js
+++ b/.bem/techs/browser.js.js
@@ -1,7 +1,6 @@
 var PATH = require('path'),
     BEM = require('bem'),
-    Q = BEM.require('q'),
-    ymPath = require.resolve('ym');
+    Q = BEM.require('q');
 
 exports.baseTechName = 'vanilla.js';
 
@@ -25,20 +24,9 @@ exports.techMixin = {
         };
     },
 
-    getYmChunk : function(output) {
-        var outputDir = PATH.resolve(output, '..'),
-            ymRelPath = PATH.relative(outputDir, ymPath);
-        return this.getBuildResultChunk(ymRelPath, ymPath);
-    },
-
-    getBuildResult : function(files, suffix, output, opts) {
-        return Q.all([
-                this.getYmChunk(output),
-                this.__base.apply(this, arguments)
-            ])
-            .spread(function(ym, res) {
-                return [ym].concat(res);
-            });
+    getYmChunk : function() {
+        var ymRelPath = this.__base.apply(this, arguments);
+        return this.getBuildResultChunk(ymRelPath);
     }
 
 };

--- a/.bem/techs/node.js.js
+++ b/.bem/techs/node.js.js
@@ -21,19 +21,20 @@ exports.techMixin = {
     },
 
     getYmChunk : function() {
+        var ymRelPath = this.__base.apply(this, arguments);
         return [
-            "if(typeof module !== 'undefined') {",
-            "modules = require('ym');",
+            "if(typeof module !== 'undefined') {\n",
+            "modules = " + this.getBuildResultChunk(ymRelPath),
             "}\n"
         ].join('');
     },
 
-    getBuildResult : function(files, suffix, output, opts) {
-        var ymChunk = this.getYmChunk();
-        return this.__base.apply(this, arguments)
-            .then(function(res) {
-                return [ymChunk].concat(res);
-            });
+    getBuildResultChunk : function(relPath, path) {
+        var fChar = relPath.charAt(0);
+        if(fChar !== '/' && fChar !== '.') {
+            relPath = './' + relPath;
+        }
+        return "require('" + relPath + "');\n";
     }
 
 };

--- a/.bem/techs/vanilla.js.js
+++ b/.bem/techs/vanilla.js.js
@@ -1,7 +1,7 @@
 var PATH = require('path'),
     BEM = require('bem'),
-    Template = BEM.require('./template'),
-    Q = BEM.require('q');
+    Q = BEM.require('q'),
+    ymPath = require.resolve('ym');
 
 exports.baseTechName = 'js';
 
@@ -33,14 +33,31 @@ exports.techMixin = {
             (moduleName += '_' + vars.ModVal);
         vars.ModuleName = moduleName;
 
-        return Template.process([
+        return BEM.template.process([
             "/*global modules:false */",
             "",
             "modules.define('{{bemModuleName}}', function(provide) {",
             "",
+            "provide();",
+            "",
             "});",
             ""
         ], vars);
+    },
+
+    getYmChunk : function(output) {
+        var outputDir = PATH.resolve(output, '..');
+        return PATH.relative(outputDir, ymPath);
+    },
+
+    getBuildResult : function(files, suffix, output, opts) {
+        return Q.all([
+                this.getYmChunk(output),
+                this.__base.apply(this, arguments)
+            ])
+            .spread(function(ym, res) {
+                return [ym].concat(res);
+            });
     }
 
 };


### PR DESCRIPTION
Closes #259 

При сборке, итоговый `bundle.node.js`, будет выглядеть так:

```
if(typeof module !== 'undefined') {
modules = require('<rel/path/to/bem-core>/node_modules/ym/modules.js');
}
require('../../common.blocks/block1/block1.node.js');
require('./blocks/some-block/some-block.node.js');
```

Это поможет не ждать, пока найдется нормальное решение для bem/bem-tools#352 и не дублировать все depend'ы библиотеки (например [bem-yana](https://github.com/narqo/bem-yana)) в проект.

\cc @veged @dfilatov какие-нибудь подводныные камни?
