### PR TITLE
isSimple() should return `true` for `null` and `undefined`

### DIFF
--- a/common.blocks/i-bem/i-bem.bemhtml
+++ b/common.blocks/i-bem/i-bem.bemhtml
@@ -197,8 +197,9 @@ function BEMContext(context, apply_) {
 BEMContext.prototype.isArray = isArray;
 
 BEMContext.prototype.isSimple = function isSimple(obj) {
+    if(!obj || obj === true) return true;
     var t = typeof obj;
-    return t === 'string' || t === 'number' || t === 'boolean';
+    return t === 'string' || t === 'number';
 };
 
 BEMContext.prototype.isShortTag = function isShortTag(t) {


### PR DESCRIPTION
С точки зрения сериализации, `null` и `undefined` — простые типы.
Удобно использовать в подобных случаях: https://github.com/bem/bem-components/blob/v2/common.blocks/dropdown/dropdown.bemhtml#L6
