### PR TITLE
Do not running tests under the Node.js <= 0.8 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "0.8"
   - "0.10"
   - "0.11"
 


### PR DESCRIPTION
closes #455 
