### PR TITLE
Add istanbul coverage report generation

### DIFF
--- a/.bem/make.js
+++ b/.bem/make.js
@@ -21,8 +21,6 @@ MAKE.decl('Arch', {
     blocksLevelsRegexp : /^.+?\.blocks$/,
     bundlesLevelsRegexp : /^.+?\.bundles$/,
 
-    libraries : [],
-
     createCustomNodes : function(common, libs, blocks) {
         var SetsNode = MAKE.getNodeClass('SetsNode');
 
@@ -30,7 +28,7 @@ MAKE.decl('Arch', {
             return;
         }
 
-        return new SetsNode({ root : this.root, arch : this.arch }).alterArch(null, libs);
+        return new SetsNode({ root : this.root, arch : this.arch }).alterArch();
     }
 
 });
@@ -120,11 +118,16 @@ MAKE.decl('ExampleNode', {
 MAKE.decl('SpecNode', {
 
     getTechs : function() {
-        return this.__base()
-            .concat([
-                'spec.js+browser.js+bemhtml',
-                'phantomjs'
-            ]);
+        return [
+            'bemjson.js',
+            'bemdecl.js',
+            'deps.js',
+            'css',
+            'spec.js+browser.js+bemhtml',
+            'bemhtml',
+            'html',
+            'phantomjs'
+        ];
     },
 
     getLevels : function() {

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 libs
 node_modules
 
+coverage.json
+/coverage
+
 *.bundles/*/*
 !*.bundles/.bem/*
 !*.bundles/*/blocks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.11"
+  - 0.10
+  - 0.11
+
+env:
+  global:
+    - GH_REF: github.com/bem/bem-core.git
+    - ISTANBUL_COVERAGE: yes
 
 matrix:
   allow_failures:
-    - node_js: "0.11"
+    - node_js: 0.11
 
 branches:
   only:
     - v1
     - v2
+
+after_success:
+  - npm install coveralls
+  - ./node_modules/.bin/istanbul report lcovonly
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && echo "Coverage data was sent to coveralls!"
+

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "Sergey Belov <peimei@ya.ru>"
   ],
   "devDependencies": {
-    "bem-pr": "git://github.com/narqo/bem-pr.git#~0.6.1"
+    "bem-pr": "git://github.com/narqo/bem-pr.git#^0.7.0"
   },
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "jshint-groups": "0.6.0",
     "jscs": "1.0.0",
     "git-hooks": "0.0.3",
-    "bower-npm-install": "~0.5.4"
+    "bower-npm-install": "~0.5.4",
+    "istanbul": "^0.2.6"
   },
   "scripts": {
     "lint": "jshint-groups && jscs .",
     "libs": "bower-npm-install",
-    "bem-test": "npm run libs && bem make -w 5 sets",
+    "bem-test": "npm run libs && bem make -w 10 desktop.specs touch.specs",
+    "bem-coverage": "ISTANBUL_COVERAGE=yes npm run bem-test",
     "test": "npm run bem-test && mocha --ui tdd --reporter spec common.blocks/i-bem/i-bem.test.bemhtml/*-test.js common.blocks/i-bem/__i18n/test/*-test.js common.blocks/i-bem/__i18n/i-bem__i18n.test.bemhtml/*-test.js"
   }
 }


### PR DESCRIPTION
**WIP! DO NOT MERGE!**

Usage:

```
# Run specs and produce coverage JSON objects for future report generation
# In case of "desktop.specs" you could use any build target, 
# like "desktop.specs/button" or "desktop.specs/i-bem__dom"
› ISTANBUL_COVERAGE=yes bem make desktop.specs
....
# Generate HTML-report using coverage data produced with `bem-make`
# from previous step
› istanbul report html
› open coverage/index.html
```
