### PR TITLE
dom: Wrong result of isFocusable() for link without href but with tabindex attribute

### DIFF
--- a/common.blocks/dom/dom.js
+++ b/common.blocks/dom/dom.js
@@ -54,6 +54,7 @@ provide(/** @exports */{
         var domNode = domElem[0];
 
         if(!domNode) return false;
+        if(domNode.hasAttribute('tabindex')) return true;
 
         switch(domNode.tagName.toLowerCase()) {
             case 'iframe':
@@ -67,10 +68,9 @@ provide(/** @exports */{
 
             case 'a':
                 return !!domNode.href;
-
-            default:
-                return domNode.hasAttribute('tabindex');
         }
+
+        return false;
     },
 
     /**

--- a/common.blocks/dom/dom.spec.js
+++ b/common.blocks/dom/dom.spec.js
@@ -72,6 +72,7 @@ describe('dom', function() {
 
         it('should returns true if given DOM elem has tabindex', function() {
             dom.isFocusable($('<span tabindex="4"/>')).should.be.true;
+            dom.isFocusable($('<a tabindex="5"/>')).should.be.true;
             dom.isFocusable($('<span/>')).should.be.false;
         });
 


### PR DESCRIPTION
fix #501 

\cc @dfilatov 
