### PR TITLE
BEM.I18N: Use modules. Closes #59

### DIFF
--- a/.bem/techs/browser.js+bemhtml.js
+++ b/.bem/techs/browser.js+bemhtml.js
@@ -19,7 +19,7 @@ exports.techMixin = {
             });
     },
 
-    concatBemhtml: function(res, output, opts) {
+    getBemhtml: function(output, opts) {
         var _this = this,
             context = this.context,
             declaration = context.opts.declaration;
@@ -40,26 +40,55 @@ exports.techMixin = {
 
                 // ugly hack for https://github.com/bem/bem-core/issues/392
                 opts.force = true;
-                var bemhtmlResults = bemhtmlTech.getBuildResults(
+
+                bemhtmlTech.getCompiledResult = function(sources) {
+                    sources = sources.join('\n');
+
+                    var BEMHTML = require('bem-xjst/lib/bemhtml'),
+                        exportName = this.getExportName(),
+                        optimize = process.env[exportName + '_ENV'] !== 'development',
+                        wrap = function(code) {
+                            return [
+                                'modules.define(\'BEMHTML\', [\'i-bem__i18n\'], function(provide, I18N) {',
+                                '    var BEM = { I18N: I18N },',
+                                '        __bem_xjst = (function(exports) {',
+                                '            ' + code + ';',
+                                '            return exports;',
+                                '        })({});',
+                                '    provide(__bem_xjst);',
+                                '});'
+                            ].join('\n');
+                        };
+
+                    return wrap(BEMHTML.generate(sources, {
+                        wrap: false,
+                        exportName: exportName,
+                        optimize: optimize,
+                        cache   : optimize && process.env[exportName + '_CACHE'] === 'on'
+                    }));
+                };
+
+                return bemhtmlTech.getBuildResults(
                         decl,
                         context.getLevels(),
                         output,
                         opts
-                    );
-
-                return bemhtmlResults
-                    .then(function(r) {
-
-                        // put bemhtml templates at the bottom of builded js file
-                        Object.keys(res).forEach(function(suffix) {
-                            // test for array as in i18n.js+bemhtml tech
-                            // there's hack to create symlink for default lang
-                            // so 'js' key is a string there
-                            Array.isArray(res[suffix]) && res[suffix].push(r['bemhtml.js']);
-                        });
-
+                    ).then(function(res) {
+                        return res['bemhtml.js'];
                     });
+            });
+    },
 
+    concatBemhtml: function(res, output, opts) {
+        return this.getBemhtml(output, opts)
+            .then(function(bemhtml) {
+                // put bemhtml templates at the bottom of builded js file
+                Object.keys(res).forEach(function(suffix) {
+                    // test for array as in i18n.js+bemhtml tech
+                    // there's hack to create symlink for default lang
+                    // so 'js' key is a string there
+                    Array.isArray(res[suffix]) && res[suffix].push(bemhtml);
+                });
             });
     }
 

--- a/.bem/techs/i18n.browser.js+bemhtml.js
+++ b/.bem/techs/i18n.browser.js+bemhtml.js
@@ -1,0 +1,2 @@
+exports.baseTechName = 'i18n.browser.js';
+exports.techMixin = require('./browser.js+bemhtml').techMixin;

--- a/.bem/techs/i18n.browser.js.js
+++ b/.bem/techs/i18n.browser.js.js
@@ -1,0 +1,91 @@
+var PATH = require('path'),
+    BEM = require('bem'),
+    Q = BEM.require('q'),
+    LangsMixin = require('./i18n').LangsMixin,
+    I18NJS = require('../../common.blocks/i-bem/__i18n/lib/i18n-js');
+
+exports.baseTechName = 'browser.js';
+
+exports.techMixin = BEM.util.extend({}, LangsMixin, {
+
+    getBuildSuffixes: function() {
+        return this.getLangs()
+            .map(this.getBuildSuffixForLang, this).concat([this.getBaseTechSuffix()]);
+    },
+
+    getBaseTechSuffix: function() {
+        return 'js';
+    },
+
+    getBuildSuffixesMap: function() {
+        var suffixes = {},
+            baseSuffixes = this.getSuffixes();
+
+        this.getBuildSuffixes()
+            .forEach(function(s) {
+                suffixes[s] = baseSuffixes;
+            }, this);
+
+        return suffixes;
+    },
+
+    getBuildSuffixForLang: function(lang) {
+        return lang + '.' + this.getBaseTechSuffix();
+    },
+
+    getBuildResults: function(decl, levels, output, opts) {
+        var _this = this,
+            source = this.getPath(output, this.getSourceSuffix()),
+            base = this.__base;
+
+        return BEM.util.readJsonJs(source)
+            .then(function(data) {
+                if (!opts) opts = {};
+                opts.ctx = {
+                    data: data
+                };
+
+                return base.call(_this, decl, levels, output, opts);
+            });
+    },
+
+    getBuildResult: function(files, suffix, output, opts) {
+        if (suffix === this.getBaseTechSuffix()) return Q.resolve(output);
+
+        var _this = this;
+        return this.__base.apply(this, arguments)
+            .then(function(res) {
+                var lang = suffix.substr(0, 2),
+                    dataLang = _this.extendLangDecl({}, opts.ctx.data['all'] || {});
+
+                dataLang = _this.extendLangDecl(dataLang, opts.ctx.data[suffix.substr(0, 2)] || {});
+
+                return res.concat(dataLang? _this.serializeI18nData(dataLang, lang) : [])
+                    .concat([_this.serializeI18nInit(lang)]);
+            });
+
+    },
+
+    serializeI18nInit: I18NJS.serializeInit,
+
+    serializeI18nData: I18NJS.serializeData,
+
+    storeBuildResult: function(path, suffix, res) {
+        if (suffix === this.getBaseTechSuffix()) {
+            return BEM.util.symbolicLink(
+                path,
+                this.getPath(
+                    res,
+                    this.getBuildSuffixForLang(this.getDefaultLang())),
+                true);
+        }
+
+        return this.__base(path, suffix, res);
+
+    },
+
+    getDependencies: function() {
+        return ['i18n'];
+    }
+
+});

--- a/.bem/techs/i18n.html.js
+++ b/.bem/techs/i18n.html.js
@@ -1,0 +1,118 @@
+var BEM = require('bem'),
+    Q = BEM.require('qq'),
+    PATH = require('path'),
+    LangsMixin = require('./i18n').LangsMixin,
+    VM = require('vm'),
+    I18NJS = require('../../common.blocks/i-bem/__i18n/lib/i18n-js');
+
+exports.baseTechName = 'html';
+
+exports.techMixin = BEM.util.extend({}, LangsMixin, {
+
+    getBaseTechSuffix: function() {
+        return 'html';
+    },
+
+    getSuffixes: function() {
+
+        return this.getLangs()
+            .map(this.getCreateSuffixForLang, this)
+            .concat([this.getBaseTechSuffix()]);
+
+    },
+
+    getCreateSuffixForLang: function(lang) {
+        return lang + '.' + this.getBaseTechSuffix();
+    },
+
+    getBemhtml: function(prefix, i18n) {
+
+        var path = this.getPath(prefix, 'bemhtml.js');
+
+        return Q.all([BEM.util.readFile(path), i18n])
+            .spread(function(bemhtml, i18n) {
+                return VM.runInThisContext([
+                        '(function(){',
+                        // make local var BEM to prevent global assignment in i18n code
+                        'var BEM = {};',
+                        i18n,
+                        bemhtml,
+                        'return BEMHTML;',
+                        '})()'
+                    ].join('\n'), path);
+            });
+
+    },
+
+    getCreateResults: function(prefix, vars) {
+
+        var _this = this,
+            source = this.getPath(prefix, this.getSourceSuffix());
+
+        return BEM.util.readJsonJs(source)
+            .then(function(data) {
+
+                var res = {};
+
+                _this.getLangs().forEach(function(lang) {
+
+                    var suffix = _this.getCreateSuffixForLang(lang),
+                        dataLang = _this.extendLangDecl({}, data['all'] || {});
+
+                    dataLang = _this.extendLangDecl(dataLang, data[lang] || {});
+
+                    res[suffix] = _this.getCreateResult(
+                        _this.getPath(prefix, suffix),
+                        suffix,
+                        BEM.util.extend({}, vars, { data: dataLang, lang: lang }));
+
+                });
+
+                // NOTE: hack to pass outputName to storeCreateResult()
+                res[_this.getBaseTechSuffix()] = prefix;
+
+                return Q.shallow(res);
+
+            });
+
+    },
+
+    getCreateResult: function(path, suffix, vars) {
+
+        var data = vars.data,
+            i18n = data && !BEM.util.isEmptyObject(data)?
+                this.serializeI18nData(data, vars.lang)
+                    .concat([this.serializeI18nInit(vars.lang)])
+                    .join('\n')
+                : '';
+
+        return this.getHtml(
+            this.getBemhtml(vars.Prefix, i18n),
+            this.getBemjson(vars.Prefix));
+
+    },
+
+    storeCreateResult: function(path, suffix, res, force) {
+
+        if (suffix === this.getBaseTechSuffix()) {
+            return BEM.util.symbolicLink(
+                path,
+                this.getPath(
+                    PATH.basename(res),
+                    this.getCreateSuffixForLang(this.getDefaultLang())),
+                true);
+        }
+
+        return this.__base(path, suffix, res, force);
+
+    },
+
+    serializeI18nInit: I18NJS.serializeInit,
+
+    serializeI18nData: I18NJS.serializeData,
+
+    getDependencies: function() {
+        return ['i18n'].concat(this.__base());
+    }
+
+});

--- a/.bem/techs/i18n.js
+++ b/.bem/techs/i18n.js
@@ -1,0 +1,131 @@
+var BEM = require('bem'),
+    Q = BEM.require('q'),
+    INHERIT = BEM.require('inherit'),
+    PATH = require('path'),
+
+    DEFAULT_LANGS = ['ru', 'en'],
+
+    pjoin = PATH.join;
+
+var LangsMixin = exports.LangsMixin = {
+
+    getLangs: function() {
+        var env = process.env.BEM_I18N_LANGS;
+        return env? env.split(' ') : [].concat(DEFAULT_LANGS);
+    },
+
+    getDefaultLang: function() {
+        return process.env.BEM_I18N_DEFAULT_LANG || this.getLangs().shift();
+    },
+
+    getSuffixForLang: function(lang) {
+        return lang + '.' + this.getTechName();
+    },
+
+    getSourceSuffix: function() {
+        return pjoin('i18n', 'all.js');
+    },
+
+    extendDecl: function(decl, ext) {
+
+        Object.keys(ext).forEach(function(lang) {
+            decl[lang] = this.extendLangDecl(decl[lang] || {}, ext[lang]);
+        }, this);
+
+        return decl;
+
+    },
+
+    extendLangDecl: function(decl, ext) {
+
+        Object.keys(ext).forEach(function(keyset) {
+
+            // fallback to BEM.util.extend() on normal keysets
+            if (keyset !== '') {
+                // TODO: here will also go merge of i18n:js and i18n:xsl content of key values in the future
+                decl[keyset] = BEM.util.extend(true, decl[keyset] || {}, ext[keyset]);
+                return;
+            }
+
+            // concatenate values of empty keysets
+            decl[keyset] || (decl[keyset] = '');
+            decl[keyset] += '\n' + ext[keyset];
+
+        });
+
+        return decl;
+
+    }
+
+};
+
+exports.Tech = INHERIT(BEM.TechV2, BEM.util.extend({}, LangsMixin, {
+
+    getSuffixForLang: function(lang) {
+        return pjoin(this.getTechName(), lang + '.js');
+    },
+
+    getCreateSuffixes: function() {
+        return this.getLangs().map(this.getSuffixForLang, this);
+    },
+
+    getBuildSuffixesMap: function() {
+        var suffixes = {};
+        suffixes[this.getSuffixForLang('all')] = this.getLangs()
+            .map(this.getSuffixForLang, this)
+            .concat(this.getSuffixForLang('all'));
+
+        return suffixes;
+    },
+
+    getBuildResult: function(files, suffix, output, opts) {
+
+        var _this = this,
+            src = _this.getSourceSuffix();
+
+        return Q.when(
+            files.reduce(function(decl, file) {
+                var all = (file.suffix === src);
+
+                return Q.all([decl, all?
+                    _this.readContent(file.absPath, file.suffix):
+                    _this.readLangContent(file.absPath, file.file.substr(0, 2))])
+                    .spread(all? _this.extendDecl.bind(_this): _this.extendLangDecl.bind(_this));
+            }, {})
+        );
+    },
+
+    storeBuildResult: function(path, suffix, res) {
+
+        BEM.util.mkdirs(PATH.dirname(path));
+
+        res = '(' + JSON.stringify(res, null, 4) + ')\n';
+        return this.__base(path, suffix, res);
+
+    },
+
+    getCreateResult: function(path, suffix, vars) {
+        return {};
+    },
+
+    storeCreateResult: function(path, suffix, res, force) {
+        res = 'module.exports = ' + JSON.stringify(res, null, 4) + ';\n';
+        return this.__base(path, suffix, res, force);
+    },
+
+    readContent: function(path, suffix) {
+        return BEM.util.readDecl(path);
+    },
+
+    readLangContent: function(path, lang) {
+
+        return this.readContent(path)
+            .then(function(c) {
+                var d = {};
+                d[lang] = c;
+                return d;
+            });
+
+    }
+
+}));

--- a/.bem/techs/i18n.node.js.js
+++ b/.bem/techs/i18n.node.js.js
@@ -1,0 +1,31 @@
+var BEM = require('bem');
+
+exports.baseTechName = 'node.js';
+
+exports.techMixin = BEM.util.extend({}, require('./i18n.browser.js').techMixin, {
+    getBuildSuffixes: function() {
+        return [this.getBaseTechSuffix()];
+    },
+    getBaseTechSuffix: function() {
+        return 'node.js';
+    },
+    getBuildResult: function(files, suffix, output, opts) {
+        var _this = this;
+
+        return this.__base(files, suffix, output, opts)
+            .then(function(res) {
+
+                var i18n = ['all'].concat(_this.getLangs())
+                    .map(function(lang) {
+                        return opts.ctx.data[lang]? _this.serializeI18nData(opts.ctx.data[lang], lang).join('\n') : '';
+                    });
+
+                return res.concat(i18n, [_this.serializeI18nInit(_this.getDefaultLang())]);
+
+            });
+
+    },
+    storeBuildResult: function(path, suffix, res) {
+        return BEM.util.writeFile(path, res);
+    }
+});

--- a/common.blocks/i-bem/__i18n/_dummy/i-bem__i18n_dummy_yes.bemhtml
+++ b/common.blocks/i-bem/__i18n/_dummy/i-bem__i18n_dummy_yes.bemhtml
@@ -2,7 +2,7 @@
 oninit(function() {
     (function(global, bem_) {
 
-        if(bem_.I18N) {
+        if(bem_.I18N || (typeof modules === 'object' && modules.isDefined('i-bem__i18n'))) {
             return;
         }
 

--- a/common.blocks/i-bem/__i18n/i-bem__i18n.deps.js
+++ b/common.blocks/i-bem/__i18n/i-bem__i18n.deps.js
@@ -1,7 +1,4 @@
 ({
-    mustDeps : [
-        { block : 'i-bem', elem : 'html' }
-    ],
     shouldDeps : [
         { elem : 'i18n', mod : 'dummy', val : 'yes' }
     ]

--- a/common.blocks/i-bem/__i18n/i-bem__i18n.i18n/all.js
+++ b/common.blocks/i-bem/__i18n/i-bem__i18n.i18n/all.js
@@ -3,6 +3,6 @@ var PATH = require('path'),
 
 module.exports = {
     'all' : {
-        '' : FS.readFileSync(PATH.resolve(__dirname, './core.js'), 'utf8')
+        '' : '(function() {' + FS.readFileSync(PATH.resolve(__dirname, './core.js'), 'utf8') + '})();'
     }
 };

--- a/common.blocks/i-bem/__i18n/i-bem__i18n.i18n/core.js
+++ b/common.blocks/i-bem/__i18n/i-bem__i18n.i18n/core.js
@@ -1,12 +1,14 @@
 /* jshint browser:true, node:true */
-/* global BEM, i18n, oninit:true */
 
-if(typeof oninit === 'undefined') oninit = function(cb) { return cb() };
+if(typeof oninit === 'undefined') {
+    var oninit = function(cb) { return cb() };
+}
 
 oninit(function() {
 
-(function(global_, bem_, undefined) {
+var hasModules = typeof modules === 'object';
 
+(function(global_, bem_, undefined) {
 // Check if BEM.I18N was already initialized
 if(typeof bem_.I18N === 'function' && bem_.I18N._proto) {
     return bem_.I18N;
@@ -18,14 +20,11 @@ if(typeof bem_.I18N === 'function' && bem_.I18N._proto) {
  *  i18n['prj']['keyset']['key'](params)
  */
 if(typeof i18n === 'undefined') {
-    /* jshint -W020 */
-    i18n = {};
-    /* jshint +W020 */
+    var i18n = {};
+    hasModules || (global_.i18n = i18n);
 }
 
-/* jshint -W020 */
-BEM = bem_;
-/* jshint +W020 */
+hasModules || (global_.BEM = bem_);
 
 var MOD_DELIM = '_',
     ELEM_DELIM = '__',
@@ -268,6 +267,10 @@ bem_.I18N = (function(base) {
     return klass;
 
 }(new _i18n()));
+
+hasModules && modules.define('i-bem__i18n', function(provide) {
+    provide(bem_.I18N);
+});
 
 })(this, typeof BEM === 'undefined'? {} : BEM);
 

--- a/common.blocks/i-bem/__i18n/lib/i18n-js.js
+++ b/common.blocks/i-bem/__i18n/lib/i18n-js.js
@@ -1,0 +1,82 @@
+/* jshint node:true */
+var TANKER = require('./tanker');
+
+exports.serializeAllData = function(data, langs, defaultLang) {
+
+    var res = ['all'].concat(langs || [])
+        .reduce(function(res, lang) {
+            return res.concat(exports.serializeData(data[lang] || {}, lang));
+        }, []);
+
+    return res.concat([exports.serializeInit(defaultLang)]);
+
+};
+
+var wrapLangDecl = function(declArr) {
+    if(!declArr.length) return '';
+
+    return [
+        '(function() {',
+        '    var hasModules = typeof modules === \'object\',',
+        '        decls = function(i18nObj) {',
+        declArr.join('\n'),
+        '\n        }',
+        'hasModules ? modules.define(\'i-bem__i18n\', function(provide, I18N) {',
+        '    decls(I18N);',
+        '    provide(I18N);',
+        '}) : decls(BEM.I18N);',
+        '})();'
+    ].join('\n');
+};
+
+exports.serializeData = function(data, lang) {
+    var buffer = [],
+        commonI18nCode;
+
+    Object.keys(data).sort().forEach(function(keyset, idx) {
+
+        // output value of empty keyset as a simple js code
+        if(keyset === '') {
+            commonI18nCode = data[keyset];
+            return;
+        }
+
+        // generate i18n declaration for normal keysets
+        buffer.push('\n            i18nObj.decl(\'' + keyset + '\', {');
+
+        Object.keys(data[keyset]).forEach(function(key, i, arr) {
+
+            TANKER.xmlToJs(data[keyset][key], function(js) {
+                buffer.push([
+                    '                ',
+                    JSON.stringify(key),
+                    ': ',
+                    js,
+                    (i === arr.length - 1? '' : ',')
+                ].join(''));
+            });
+
+        });
+
+        buffer.push([
+            '            }, {',
+            '                "lang": "' + lang + '"',
+            '            });'
+        ].join('\n'));
+
+    });
+
+    return [
+        commonI18nCode,
+        wrapLangDecl(buffer)
+    ];
+};
+
+exports.serializeInit = function(lang) {
+    return [
+        '\ntypeof modules === \'object\' ? modules.define(\'i-bem__i18n\', function(provide, I18N) {',
+        '    I18N.lang(\'' + lang + '\');',
+        '    provide(I18N);',
+        '}) : BEM.I18N.lang(\'' + lang + '\');'
+    ].join('\n');
+};

--- a/common.blocks/i-bem/__i18n/lib/tanker.js
+++ b/common.blocks/i-bem/__i18n/lib/tanker.js
@@ -1,0 +1,370 @@
+/* jshint node:true */
+var DOM = require('dom-js'),
+    QUOTE_CHAR = '"',
+    SINGLE_QUOTE_CHAR = '\'',
+    isArray = Array.isArray,
+    isJson = function(obj) {
+        try {
+            if(isString(obj)) {
+                var jsonStart = obj.trim().charAt(0);
+                if(jsonStart === '{' || jsonStart === '[')
+                    return JSON.parse(obj);
+            }
+            return false;
+        } catch(e) {
+            return false;
+        }
+    },
+    isString = function(str) {
+        return typeof str === 'string';
+    },
+    isSimple = function(obj) {
+        var type = typeof obj;
+        return type === 'string' || type === 'number';
+    },
+    parseXml = exports.parseXml = function(xml, cb) {
+
+        isSimple(xml) || (xml = JSON.stringify(xml));
+
+        try {
+            new DOM.DomJS().parse('<root>' + xml + '</root>', function(err, dom) {
+                if(err) return;
+                cb(dom.children);
+            });
+        } catch(e) {
+            parseXml(DOM.escape(xml), cb);
+        }
+
+    },
+    domToJs = exports.domToJs = function(nodes) {
+
+        var code = expandNodes(toCommonNodes(nodes), jsExpander);
+
+        if(!code.length) {
+            return '\'\'';
+        }
+
+        return code.length === 1 &&
+            (code[0].charAt(0) === QUOTE_CHAR || code[0].charAt(0) === SINGLE_QUOTE_CHAR )?
+                code[0] : 'function(params) { return ' + code.join(' + ') + ' }';
+
+    };
+
+exports.xmlToJs = function(xml, cb) {
+
+    parseXml(xml, function(nodes) {
+        cb(domToJs(nodes));
+    });
+
+};
+
+/**
+ * @param {Array|String|Number} node
+ * @param {Function} expanderFn
+ */
+function expandNodes(node, expanderFn) {
+
+    if(isSimple(node)) return node;
+
+    return node.map(function(item) {
+        return isSimple(item)? item : expanderFn(item);
+    });
+
+}
+
+/**
+ * @param {Array} node
+ * @returns {String}
+ */
+function jsExpander(node, _raw) {
+
+    _raw === null && (_raw = false);
+
+    var currentExpander = function(node) {
+            return jsExpander(node, _raw);
+        },
+        rawExpander = function(node) {
+            return jsExpander(node, true);
+        };
+
+    if(!node) {
+        // FIXME: should we throw?
+        console.warn('[WARN]: Undefined item');
+        return '';
+    }
+
+    var nodeclass = node.pop(),
+        code;
+
+    switch(nodeclass) {
+
+    case 'TANKER_DYNAMIC':
+        // [ keyset, key, [params] ]
+        code = expandNodes(node, currentExpander);
+        return 'this.keyset(\'' + code[0] + '\').key(\'' + code[1] + '\', ' + (code[2] || '{}') + ')';
+
+    case 'JS_DYNAMIC':
+        // [ code ]
+        code = '(function(params) { ' + expandNodes(node[0], rawExpander).join('') + ' }).call(this, params);';
+        return code;
+
+    case 'XSL_DYNAMIC':
+        // [ code ]
+        return '';
+
+    case 'XML':
+        // [ tag, attrs, [content] ]
+        var tag = node[0],
+            attrs = node[1],
+            prop = [],
+            s = '', t, c;
+
+        code = [];
+
+        for(c in attrs) { prop.push([c, SINGLE_QUOTE_CHAR + attrs[c] + SINGLE_QUOTE_CHAR].join('=')); }
+        prop = prop.length? jsQuote(' ' + prop.join(' ')) : '';
+
+        c = '';
+        t = '"<' + tag + prop;
+
+        if(node[2].length) {
+            s = ' + ';
+
+            t += '>"';
+            code.push(t);
+
+            c = expandNodes(node[2], currentExpander);
+            isArray(c) || (c = [c]);
+            [].push.apply(code, c);
+
+            code.push(t = '"</' + tag + '>"');
+        } else {
+            t += '/>"';
+            code.push(t);
+        }
+
+        return code.join(s);
+
+    case 'PARAMS':
+        // [ [params] ]
+        return '{ ' + expandNodes(node, currentExpander).join(', ') + ' } ';
+
+    case 'PARAM':
+        // [ name, [code] ]
+        code = expandNodes(node[1], currentExpander);
+        return [node[0], isArray(code)? code.join(' + ') : code].join(': ');
+
+    case 'PARAM-CALL':
+        // [ key ]
+        return 'params[' + node[0] + ']';
+
+    case 'TEXT':
+        // [ text ]
+        return _raw? node[0] : SINGLE_QUOTE_CHAR + jsQuote(node[0]) + SINGLE_QUOTE_CHAR;
+
+    default:
+        throw new Error('Unexpected item type: ' + nodeclass);
+
+    }
+
+}
+
+/**
+ * @param {Node[]} nodes
+ * @returns {AST}
+ */
+function toCommonNodes(nodes) {
+
+    var code = [];
+
+    nodes.forEach(function(node) {
+        if(node.name) {
+            code.push(_node(node));
+        } else if(node.text) {
+            var text = _json(node.text);
+            if(text) code.push(text);
+        }
+    });
+
+    return code;
+
+}
+
+/**
+ * @param {Object|Node} str
+ * @returns {AST|String}
+ */
+function _text(str) {
+
+    if(!isSimple(str)) return '';
+
+    str = str.replace(/\n\s\s+/g, '\n ');
+
+    if(!str.length) return '';
+
+    return [str, 'TEXT'];
+
+}
+
+/**
+ * @returns {AST}
+ */
+function _empty() {
+    return ['', 'TEXT'];
+}
+
+/**
+ * @param {Node} node
+ * @returns {AST}
+ */
+function _node(node) {
+
+    var name = node.name;
+    switch(name) {
+
+    case 'i18n:dynamic':
+        var attrs = node.attributes;
+        if(attrs && attrs.key) {
+            // tanker dynamic
+            var keyset = _keyset(attrs),
+                params = _params(node.children);
+
+            return [keyset, attrs.key, params, 'TANKER_DYNAMIC'];
+
+        }
+
+        // custom
+        return _dynamic(node.children);
+
+    case 'i18n:param':
+        if(node.firstChild())
+            return _paramCall(node.children[0]);
+
+    }
+
+    if(!~name.indexOf(':'))
+        return _xml(node);
+
+}
+
+/**
+ * @param {Node} node
+ * @returns {AST}
+ */
+function _xml(node) {
+    return [node.name, node.attributes, toCommonNodes(node.children), 'XML'];
+}
+
+/**
+ * @param {Array|Object} nodes
+ * @returns {AST}
+ */
+function _json(nodes) {
+
+    var json;
+    if(!(json = isJson(nodes)))
+        return _text(nodes);
+
+    if(isArray(json)) {
+        // FIXME: array should always produce `plural_adv`?
+        // FIXME: `none` value for json
+        var params = [
+                ['"count"', [['"count"', 'PARAM-CALL']], 'PARAM']
+            ]
+            .concat(['one', 'some', 'many', 'none'].map(function(p, i) {
+                return [quotify(p), quotify(json[i] || ''), 'PARAM'];
+            }));
+
+        params.push('PARAMS');
+
+        // FIXME: hardcode
+        return ['i-tanker__dynamic', 'plural_adv', params, 'TANKER_DYNAMIC'];
+    }
+
+    return _text(nodes.toString());
+
+}
+
+/**
+ * @param {Node[]} nodes
+ * @returns {AST}
+ */
+function _dynamic(nodes) {
+
+    var code = [];
+
+    nodes.forEach(function(node) {
+        var name = node.name;
+
+        if(name === 'i18n:js') {
+            code.push([toCommonNodes(node.children), 'JS_DYNAMIC']);
+        //} else if(name === 'i18n:xsl') {
+        //    code.push([toCommonNodes(node.children), 'XSL_DYNAMIC']);
+        }
+
+    });
+
+    return code.length === 1? code[0] : code;
+
+}
+
+/**
+ * @param {Node[]} nodes
+ * @returns {AST}
+ */
+function _params(nodes) {
+
+    var params = [];
+
+    nodes.forEach(function(node) {
+        if(!node.name) return;
+        params.push(_param(node));
+    });
+
+    params.push('PARAMS');
+
+    return params;
+
+}
+
+/**
+ * @param {Node} param
+ * @returns {AST}
+ */
+function _param(param) {
+    var name = param.name.replace(/i18n:/, ''),
+        val = toCommonNodes(param.children);
+
+    val.length || val.push(_empty());
+
+    return [JSON.stringify(name), val, 'PARAM'];
+}
+
+/**
+ * @param {Node} param
+ * @returns {AST}
+ */
+function _paramCall(param) {
+    return [JSON.stringify(param.text), 'PARAM-CALL'];
+}
+
+/**
+ * @param {Node} param
+ * @returns {String}
+ */
+function _keyset(param) {
+    // FIXME: get rid of Yandex.Tanker specifics
+    return ((param.project && param.project === 'tanker')? 'i-' + param.project + '__' : '') + param.keyset;
+}
+
+/** Helpers **/
+
+function jsQuote(s) {
+    return '' + s.replace(/([\\\/\'\r\n])/g, '\\$1');
+}
+
+function quotify(str) {
+    if(isString(str))
+       return QUOTE_CHAR + str + QUOTE_CHAR;
+    return str;
+}

--- a/common.blocks/page/page.deps.js
+++ b/common.blocks/page/page.deps.js
@@ -1,8 +1,8 @@
 ({
     mustDeps : 'i-bem',
     shouldDeps : [
-        { block : 'i-bem', elem : 'dom', mods : { init : 'auto' } },
-        { block : 'ua' },
+        { block : 'i-bem-dom', elems : { elem : 'init', mods : { auto : true } } },
+        'ua',
         { elems : ['css', 'js'] }
     ]
 })

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "ym": "0.0.15",
     "bem-xjst": "0.4.0",
     "bemhtml-compat": "~0.0.4",
-    "bem-environ": "~1.2.0"
+    "bem-environ": "~1.2.0",
+    "dom-js": "0.0.9"
   },
   "devDependencies": {
     "bem": "~0.7.2",


### PR DESCRIPTION
Quite ugly but working.

Works the same as in `bem-bl` for `i18n.html` tech and via `modules.require(['i-bem__i18n'])` for `browser.js` and `node.js`. In templates `BEM.I18N` syntax is left for backward compatibility but it doesn't pollute global scope in browser or node.js bundle. Still I'm not sure it's a good idea to keep it like that.

To use `i18n` in BEMHTML within `node.js` bundle needed something like this

``` js
var vm = require('vm'),
    BEMHTML = require('fs').readFileSync('./desktop.bundles/index/index.bemhtml.js');

modules.define('BEMHTML', ['i-bem__i18n'], function(provide, I18N) {
    var ctx = vm.createContext({ BEM: { I18N: I18N } });
    vm.runInContext(BEMHTML, ctx);
    provide(ctx.BEMHTML);
});
```

but it's possible to write `i18n.bemhtml` tech to build bemhtml bundle with `i18n` code to use it with `require('index.bemhtml.js').BEMHTML`

Here's [project-stub branch](https://github.com/bem/project-stub/tree/i18n) with `i18n` to test.

@narqo @dfilatov @veged
