### PR TITLE
Return an original string if decode failed

### DIFF
--- a/common.blocks/querystring/__uri/querystring__uri.spec.js
+++ b/common.blocks/querystring/__uri/querystring__uri.spec.js
@@ -1,0 +1,35 @@
+modules.define('spec', ['querystring__uri'], function(provide, qs) {
+
+describe('querystring__uri', function() {
+    describe('decodeURIComponent()', function() {
+        
+        it('should be able to decode cp1251 encoded params', function() {
+            qs.decodeURIComponent('%F2%E0%E1%EB%EE').should.be.eql('табло');
+        });
+    
+        it('should not fall on params encoded with unknown encoding', function() {
+            qs.decodeURIComponent('%COCO%C0C0').should.be.eql('%COCO%C0C0');
+        });
+        
+    });
+    
+    describe('decodeURI()', function() {
+        
+        it('should be able to decode url with cp1251 encoded params', function() {
+            qs
+                .decodeURI('http://test.com/ololo/trololo.html?text=%F2%E0%E1%EB%EE')
+                .should.be.eql('http://test.com/ololo/trololo.html?text=табло');
+        });
+    
+        it('should not fall on url with params encoded with unknown encoding', function() {
+            qs
+                .decodeURI('http://test.com/ololo/trololo.html?text=%COCO%C0C0')
+                .should.be.eql('http://test.com/ololo/trololo.html?text=%COCO%C0C0');
+        });
+        
+    });
+});
+
+provide();
+
+});

--- a/common.blocks/querystring/__uri/querystring__uri.vanilla.js
+++ b/common.blocks/querystring/__uri/querystring__uri.vanilla.js
@@ -13,23 +13,27 @@ function convert(str) {
     return str.replace(
         /%.{2}/g,
         function($0) {
-            return map[$0];
+            return map[$0] || $0;
         });
 }
 
 function decode(fn,  str) {
-    var res = '';
-    // try/catch block for getting the encoding of the source string
-    // error is thrown if a non-UTF8 string is input
-    // if the string was not decoded,  it is returned without changes
+    var decoded = '';
+    
+    // Try/catch block for getting the encoding of the source string.
+    // Error is thrown if a non-UTF8 string is input.
+    // If the string was not decoded, it is returned without changes.
     try {
-        res = fn(str);
+        decoded = fn(str);
+    } catch (e1) {
+        try {
+            decoded = fn(convert(str));
+        } catch (e2) {
+            decoded = str;
+        }
     }
-    catch(e) {
-        res = fn(convert(str));
-    }
-
-    return res;
+    
+    return decoded;
 }
 
 provide(/** @exports */{


### PR DESCRIPTION
Сделал логику эквивалетной аналогичному блоку в `bem-bl`:
https://github.com/bem/bem-bl/blob/dev/blocks-common/i-jquery/__decodeuri/i-jquery__decodeuri.js
