### PR TITLE
Make elem method a little bit smarter

### DIFF
--- a/common.blocks/i-bem/__dom/i-bem__dom.js
+++ b/common.blocks/i-bem/__dom/i-bem__dom.js
@@ -758,7 +758,7 @@ var DOM = BEM.decl('i-bem__dom',/** @lends BEMDOM.prototype */{
         var key = name + buildModPostfix(modName, modVal),
             res;
 
-        if(!(res = this._elemCache[key])) {
+        if(!(res = this._elemCache[key]) || !res.parent().length) {
             res = this._elemCache[key] = this.findElem(name, modName, modVal);
             res.__bemElemName = name;
         }


### PR DESCRIPTION
Now we have some problem with very aggressive elem caching e.g
bemjson:

```
{
    block: 'test',
    js: true,
    content:  {
        elem: 'el',
        content: 'first'
    }
}
```

.js:

```
{
modules.require(['i-bem__dom'], function(DOM) {
    DOM.decl('test',{
        onSetMod: {
            'js': function() {
               console.log(this.elem('el').text()); // OK - first
               DOM.update(this.domElem, '<div class="test__el">second</div>');
               console.log(this.elem('el').text()); // WTF - first
            }
        }
        });
});
}
```

So it's reach field for mistake, or we must use findElem in all of the cases for simplify things.

I think this change have a little impact on performance, and may make things better. May be :)
