### PR TITLE
`pointerpress`/`pointerrelease` event should be fired if only left mouse button is pressed

### DIFF
--- a/common.blocks/jquery/__event/_type/jquery__event_type_pointerpressrelease.js
+++ b/common.blocks/jquery/__event/_type/jquery__event_type_pointerpressrelease.js
@@ -7,9 +7,11 @@ $.each({
     function eventHandler(e) {
         var res, origType = e.handleObj.origType;
 
-        e.type = spec;
-        res = $.event.dispatch.apply(this, arguments);
-        e.type = origType;
+        if(!e.button) {
+            e.type = spec;
+            res = $.event.dispatch.apply(this, arguments);
+            e.type = origType;
+        }
 
         return res;
     }


### PR DESCRIPTION
fixes #607 

backport #616 onto v3
