### PR TITLE
Links to external docs updated, "Russian version only" note inserted where applicable

### DIFF
--- a/common.docs/bemjson/bemjson.en.md
+++ b/common.docs/bemjson/bemjson.en.md
@@ -10,15 +10,14 @@ The guide describes:
 * BEMJSON syntax for data description.
 
 
-**The target audience for this guide**  are web developers and HTML coders who use the
-[BEM methodology](http://bem.info/method/).
+**The target audience for this guide**  are web developers and HTML coders who use the [BEM methodology](https://bem.info/method/).
 
 The reader is assumed to be familiar with:
 
 * HTML
 * JavaScript
 * CSS
-* BEM
+* [BEM](https://bem.info/method/)
 
 
 The description of tools for generating a BEM tree in BEMJSON format is **beyond the scope of this document**.
@@ -44,10 +43,10 @@ BEMJSON is a JavaScript data structure (object) with a set of extra conventions 
 <a id="bemcore"></a>
 ###BEMJSON and data templating in bem-core
 
-A BEMJSON-formatted BEM tree is an integral part of the [data templating](http://bem.info/technology/bemhtml/current/templating/) mechanisms implemented in `bem-core`. BEMJSON is used as an input data format for these template engines:
+A BEMJSON-formatted BEM tree is an integral part of the data templating mechanisms implemented in `bem-core`. BEMJSON is used as an input data format for these template engines:
 
-* [BEMTREE](http://bem.info/technology/bemtree/current/bemtree/)
-* [BEMHTML](http://bem.info/technology/bemhtml/current/intro/)
+* [BEMTREE](https://bem.info/technology/bemtree/current/bemtree/)
+* [BEMHTML](https://bem.info/technology/bemhtml/current/intro/)
 
 From a BEMTREE and BEMHTML templates perspective, a portion of input data corresponding to the current BEM-tree element (node) and its child elements is contained in the context field `this.ctx`.
 
@@ -59,7 +58,7 @@ From a BEMTREE and BEMHTML templates perspective, a portion of input data corres
 <a id="sbor"></a>
 ###BEMJSON and the build process
 
-Certain build systems, such as [bem-tools](http://bem.info/tools/bem/bem-tools/), use files that contain the literal record BEMJSON as a build **declaration**. In `bem-tools`, `bemjson.js`-suffixed files serve this purpose. Based on a BEM tree defined in such files, the build system determines a set of BEM entities whose implementations are to be built from block folders.
+Certain build systems, such as [bem-tools](https://bem.info/tools/bem/bem-tools/), use files that contain the literal record BEMJSON as a build **declaration**. In `bem-tools`, `bemjson.js`-suffixed files serve this purpose. Based on a BEM tree defined in such files, the build system determines a set of BEM entities whose implementations are to be built from block folders.
 
 In practice, it works like this: first, based on the `bemjson.js` declaration and the build settings, the build tool creates a basic declaration file in `bemdecl.js` format. The latter is then used to build a file in `deps.js` format that describes build dependencies. The dependencies file is a flat list of BEM entities involved in the build, which looks like this:
 
@@ -95,8 +94,8 @@ The part of a filename that follows the first occurrence of the period is consid
 
 **See also**:
 
-* [Dependencies in bem-tools](http://bem.info/tools/bem/bem-tools/depsjs/)
-* [Building and connecting BEMTREE and BEMHTML technology bundles](http://ru.bem.info/technology/bemhtml/2.3.0/templating/#polymorph) (Russian version only)
+* [Dependencies in bem-tools](https://bem.info/tools/bem/bem-tools/depsjs/)
+* [Building and connecting BEMTREE and BEMHTML technology bundles](https://ru.bem.info/technology/bemhtml/current/templating/#polymorph) (Russian version only)
 
 
 
@@ -202,7 +201,7 @@ BEM entities are represented in BEMJSON as objects that can contain the followin
 
 **See also**:
 
-* [Context-aided completion of BEM entities](http://ru.bem.info/technology/bemhtml/2.3.0/templating/#extensionbem) (Russian version only)
+* [Context-aided completion of BEM entities](https://ru.bem.info/technology/bemhtml/current/templating/#extensionbem) (Russian version only)
 
 <a name="notionhtml"></a>
 
@@ -282,7 +281,7 @@ The following fields in BEMJSON are used to control HMTL rendering:
 </tr>
 </table>
 
-Note that the names and meanings of these HTML-specific BEMJSON fields are equivalent to those of the corresponding BEMHTML [standard modes](http://bem.info/technology/bemhtml/2.3.0/reference/#standardmoda) (tags, attributes, classes, etc.) If the same HTML aspects are specified **in both the input data and BEMHTML templates**, the values specified in the BEMHTML templates take priority.
+Note that the names and meanings of these HTML-specific BEMJSON fields are equivalent to those of the corresponding BEMHTML [standard modes](https://bem.info/technology/bemhtml/current/reference/#standardmoda) (tags, attributes, classes, etc.) If the same HTML aspects are specified **in both the input data and BEMHTML templates**, the values specified in the BEMHTML templates take priority.
 
 During the HTML generation process, the BEMHTML template engine will perform one of two actions:
 
@@ -318,7 +317,7 @@ An example of a custom field is the field `url` in a link block:
 }
 ```
 
-To see how data from a custom field is used, refer to the section [Condition-based template selection](http://http://bem.info/technology/bemhtml/2.3.0/reference/#select_template) of the BEMHTML document.
+To see how data from a custom field is used, refer to the section [Condition-based template selection](https://bem.info/technology/bemhtml/current/reference/#select_template) of the BEMHTML document.
 
 <a name="customjs"></a>
 

--- a/common.docs/bemtree-reference/bemtree-reference.en.md
+++ b/common.docs/bemtree-reference/bemtree-reference.en.md
@@ -10,36 +10,36 @@ The guide describes:
 * Input data processing and BEMJSON generation;
 * BEMTREE-based solutions to some typical problems.
 
-**The target audience for this guide** are web developers and HTML coders who use the [BEM methodology](http://bem.info/method/).
+**The target audience for this guide** are web developers and HTML coders who use the [BEM methodology](https://bem.info/method/).
 
 The reader is assumed to be familiar with:
 
 * HTML
 * JavaScript
 * CSS
-* [BEMHTML](http://bem.info/technology/bemhtml/current/reference/)
-* [BEMJSON](http://bem.info/technology/bemjson/current/bemjson/)
-* [BEM](http://bem.info/method/)
+* [BEMHTML](https://bem.info/technology/bemhtml/current/reference/)
+* [BEMJSON](https://bem.info/technology/bemjson/current/bemjson/)
+* [BEM](https://bem.info/method/)
 
 **This document does not cover** the setup of the development environment, the template compilation procedure or the process of receiving data from the back end.
 
 
 <a name="bemtree"></a>
 
-## BEMTREE features
+## BEMTREE Features
 
 <a name="arch"></a>
 
 ### Architecture
 
-BEMTREE templates are processed using the module [bem-xjst](http://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMTREE default template – [i-bem.bemtree](https://github.com/bem/bem-core/blob/v2/common.blocks/i-bem/i-bem.bemtree).
+BEMTREE templates are processed using the module [bem-xjst](https://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMTREE default template – [i-bem.bemtree](https://github.com/bem/bem-core/blob/v2/common.blocks/i-bem/i-bem.bemtree).
 
 BEMTREE-specific logic is implemented at `i-bem.bemtree` template level. This default template defines:
 
 * the set of standard modes and in what order to call them;
 * available context fields.
 
-For a detailed description of BEMTREE's architecture, see the section “Architecture of BEMHTML and BEMTREE templates” of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
+For a detailed description of BEMTREE's architecture, see the section “Architecture of BEMHTML and BEMTREE templates” of the [Data templating in bem-core](https://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
 
 
 <a name="uts"></a>
@@ -55,7 +55,7 @@ BEMTREE is a BEM-XJST template engine. In other words, BEMTREE uses **BEM-XJST s
 
 <a name="basic"></a>
 
-## Key concepts
+## Key Concepts
 
 <a name="template"></a>
 ### Templating in a nutshell
@@ -153,9 +153,9 @@ Thus the BEM tree of the entire document is built element by element.
 
 You can find detailed information about them in the respective sections of the documentation about templating in bem-core:
 
-* [Template](http://ru.bem.info/technology/bemhtml/current/templating/#template_ingeneral)
-* [Mode](http://ru.bem.info/technology/bemhtml/current/templating/#moda)
-* [Context](http://ru.bem.info/technology/bemhtml/current/templating/#context)
+* Template
+* Mode
+* Context
 
 
 <a name="syntax"></a>
@@ -168,7 +168,7 @@ Syntax-wise, BEMTREE differs from BEMHTML in what sets of context fields and sta
 
 <a name="standardmoda"></a>
 
-## Standard modes
+## Standard Modes
 
 The default BEMTREE template defines a set of standard modes which specify the default order for processing an input BEM tree (BEMJSON) and generating an output BEMJSON.
 
@@ -235,7 +235,7 @@ The action performed in the empty mode depends on the element type of the contex
 
 Defining a template in the empty mode (sub-predicate `mode(this._mode === '')`) only makes sense if it is necessary to override the traversal process for the input tree.
 
-Calling templates in the empty mode (the `apply('')` construction in the template body) is necessary if the one-to-one mapping principle of "input BEM entity - output BEMJSON element" has to be broken - e.g., to generate more than one element per input entity. Such a call is performed automatically when using the [`applyCtx` construction](#applyctx).
+Calling templates in the empty mode (the `apply('')` construction in the template body) is necessary if the one-to-one mapping principle of "input BEM entity - output BEMJSON element" has to be broken - e.g., to generate more than one element per input entity. Such a call is performed automatically when using the `applyCtx` construction.
 
 **See also**:
 
@@ -321,7 +321,7 @@ A template must be defined in the `content` mode (sub-predicate `content()`) if 
 
 <a name="context_field"></a>
 
-## Context fields
+## Context Fields
 
 As it runs, the BEMTREE template engine builds a data structure containing information about the BEMJSON node being processed and the state of processing. In addition, several auxiliary functions are available in the context.
 
@@ -336,7 +336,7 @@ All context fields can be divided into two categories:
 
 **See also**:
 
-  * [Context](http://ru.bem.info/technology/bemhtml/current/templating/#context)(Russian version only)
+  * [Context](https://ru.bem.info/technology/bemhtml/current/templating/#context) (Russian version only)
 
 
 <a name="contextdependent"></a>
@@ -369,7 +369,7 @@ BEMTREE extends the set of context-independent fields of BEM-XJST with only one 
 
 <a name="examples"></a>
 
-## Examples and recipes
+## Examples and Recipes
 
 <a name="bringing_input"></a>
 
@@ -448,7 +448,7 @@ Let's assume that the source data is saved in the context field `this.ctx.data`.
 
 #### Problem
 
-Two different templates are defined for the same BEM entity (`block b1`) at different [redifinition levels](http://bem.info/method/filesystem/). Each of the templates defines its content in the `content` mode.
+Two different templates are defined for the same BEM entity (`block b1`) at different [redifinition levels](https://bem.info/method/filesystem/). Each of the templates defines its content in the `content` mode.
 
 The content defined at the first level of redefinition should be inherited at the second level, and also some extra content should be added. An analogue of `<xsl:apply-imports/>` is required.
 
@@ -488,7 +488,7 @@ block('b1').content()([
 
 **See also**:
 
-  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyNext construction](https://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 
 <a name="wrappingunit"></a>
@@ -585,9 +585,9 @@ block('box').match(!this.ctx._processed).content()(applyCtx({'ctx._processed':tr
 
 **See also**:
 
-  * [The apply construction](http://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
-  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
-  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
+  * [The apply construction](https://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
+  * [The applyNext construction](https://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyCtx construction](https://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 
 <a name="check_predicate"></a>
@@ -655,6 +655,6 @@ When creating BEMTREE templates, the same techniques can be used as are applicab
 
 **See also**:
 
-* [BEMHTML: Examples and recipes](http://bem.info/technology/bemhtml/current/reference/#examples)
-* [BEMHTML](http://bem.info/technology/bemhtml/current/reference/)
-* [BEMJSON](http://bem.info/technology/bemjson/current/bemjson/)
+* [BEMHTML: Examples and recipes](https://bem.info/technology/bemhtml/current/reference/#examples)
+* [BEMHTML](https://bem.info/technology/bemhtml/current/reference/)
+* [BEMJSON](https://bem.info/technology/bemjson/current/bemjson/)

--- a/common.docs/bemtree-reference/bemtree-reference.en.md
+++ b/common.docs/bemtree-reference/bemtree-reference.en.md
@@ -29,6 +29,7 @@ The reader is assumed to be familiar with:
 ## BEMTREE features
 
 <a name="arch"></a>
+
 ### Architecture
 
 BEMTREE templates are processed using the module [bem-xjst](http://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMTREE default template – [i-bem.bemtree](https://github.com/bem/bem-core/blob/v2/common.blocks/i-bem/i-bem.bemtree).
@@ -38,7 +39,7 @@ BEMTREE-specific logic is implemented at `i-bem.bemtree` template level. This de
 * the set of standard modes and in what order to call them;
 * available context fields.
 
-For a detailed description of BEMTREE's architecture, see the section “Architecture of BEMHTML and BEMTREE templates” of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (available only in Russian).
+For a detailed description of BEMTREE's architecture, see the section “Architecture of BEMHTML and BEMTREE templates” of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
 
 
 <a name="uts"></a>
@@ -335,7 +336,7 @@ All context fields can be divided into two categories:
 
 **See also**:
 
-  * [Context](http://ru.bem.info/technology/bemhtml/current/templating/#context)
+  * [Context](http://ru.bem.info/technology/bemhtml/current/templating/#context)(Russian version only)
 
 
 <a name="contextdependent"></a>
@@ -487,7 +488,7 @@ block('b1').content()([
 
 **See also**:
 
-  * [applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext)
+  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 
 <a name="wrappingunit"></a>
@@ -520,7 +521,7 @@ block('b-inner').def()
 
 **See also**:
 
-  * [The `applyCtx` construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx)
+  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 <a name="additionbem"></a>
 
@@ -584,9 +585,9 @@ block('box').match(!this.ctx._processed).content()(applyCtx({'ctx._processed':tr
 
 **See also**:
 
-  * [The `apply` construction](http://ru.bem.info/technology/bemhtml/current/templating/#apply)
-  * [The `applyNext` construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext)
-  * [The `applyCtx` construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx)
+  * [The apply construction](http://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
+  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 
 <a name="check_predicate"></a>
@@ -654,6 +655,6 @@ When creating BEMTREE templates, the same techniques can be used as are applicab
 
 **See also**:
 
-* [BEMHTML: Examples and recipes](http://bem.info/technology/bemhtml/current/reference/)
+* [BEMHTML: Examples and recipes](http://bem.info/technology/bemhtml/current/reference/#examples)
 * [BEMHTML](http://bem.info/technology/bemhtml/current/reference/)
 * [BEMJSON](http://bem.info/technology/bemjson/current/bemjson/)

--- a/common.docs/reference/reference.en.md
+++ b/common.docs/reference/reference.en.md
@@ -9,15 +9,15 @@ The guide describes:
 * BEMHTML's main features distinguishing it from other template engines;
 * BEMHTML-based solutions to some typical problems.
 
-**The target audience for this guide** are web developers and HTML coders who use the [BEM-methodology](http://bem.info/method/).
+**The target audience for this guide** are web developers and HTML coders who use the [BEM-methodology](https://bem.info/method/).
 
 The reader is assumed to be familiar with:
 
 * HTML
 * JavaScript
 * CSS
-* BEM
-* [BEMJSON](http://bem.info/technology/bemjson/current/bemjson/)
+* [BEM](https://bem.info/method/)
+* [BEMJSON](https://bem.info/technology/bemjson/current/bemjson/)
 
 **This document does not cover** the setup of the development environment, the template compilation procedure, or BEMJSON syntax.
 
@@ -29,14 +29,14 @@ The reader is assumed to be familiar with:
 
 #### Architecture
 
-BEMHTML templates are processed using the module [bem-xjst](http://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMHTML default template – [i-bem.bemhtml](https://github.com/bem/bem-core/blob/v1/common.blocks/i-bem/i-bem.bemhtml).
+BEMHTML templates are processed using the module [bem-xjst](https://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMHTML default template – [i-bem.bemhtml](https://github.com/bem/bem-core/blob/v1/common.blocks/i-bem/i-bem.bemhtml).
 
 BEMHTML-specific logic is implemented at `i-bem.bemhtml` template level. This default template defines:
 
 * the set of standard modes and in what order to call them;
 * available context fields.
 
-For a detailed description of BEMHTML's architecture, see the section [Architecture of BEMHTML and BEMTREE templates](http://ru.bem.info/technology/bemhtml/current/templating/#bemx_arch) of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
+For a detailed description of BEMHTML's architecture, see the section "Architecture of BEMHTML and BEMTREE templates" of the [Data templating in bem-core](https://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
 
 <a name="uts"></a>
 ### Support of BEM-XJST templating
@@ -54,22 +54,22 @@ BEMHTML is a BEM-XJST template engine. In other words, BEMHTML uses **BEM-XJST s
 
 <a id="inputdata"></a>
 
-#### Input Data: BEMJSON
+#### Input data: BEMJSON
 
 BEMHTML is based on JavaScript, so BEMJSON - a JavaScript data structure (object) with a set of extra conventions on the representation of BEM entities - is used as the BEM tree standard format.
 
 The purpose of the BEMHTML template engine is to convert an input BEM tree to an HTML document. It should be noted though that complex transformations of input data at template engine level are likely to compromise the flexibility and maintainability of the template engine, so it's best to keep things simple. In terms of template writing this means creating the most basic statements that map each available type of BEM entity with an appropriate HTML presentation.
 
-Therefore the input BEM tree structure should be **view**-oriented, to preclude the need to change blocks and elements or their order during the HTML tree generation process. Transforming the BEM tree into such a format should be done at back-end level, i.e. upstream - before the data hits the BEMHTML template engine (e.g. using the [BEMTREE](http://bem.info/technology/bemtree/2.3.0/bemtree/) technology).
+Therefore the input BEM tree structure should be **view**-oriented, to preclude the need to change blocks and elements or their order during the HTML tree generation process. Transforming the BEM tree into such a format should be done at back-end level, i.e. upstream - before the data hits the BEMHTML template engine (e.g. using the [BEMTREE](https://bem.info/technology/bemtree/current/bemtree/) technology).
 
 The view-oriented data format is discussed in the news feed example, under the
-[Converting input data into view-oriented format](http://bem.info/technology/bemtree/current/bemtree/#bringing_input) problem in the **Examples and Recipes** section of the [BEMTREE](http://bem.info/technology/bemtree/current/bemtree/) document.
+[Converting input data into view-oriented format](https://bem.info/technology/bemtree/current/bemtree/#bringing_input) problem in the **Examples and Recipes** section of the [BEMTREE](https://bem.info/technology/bemtree/current/bemtree/) document.
 
 Conversely, the details of the HTML page layout, which is the front-end developer's responsibility, should only be specified at template engine level. For an example of how such a solution can be implemented, see [Adding BEM entities to solve layout problems](#additionbem).
 
 **See also**:
 
-  * [BEMJSON syntax](http://bem.info/technology/bemjson/current/#bemjson)
+  * [BEMJSON syntax](https://bem.info/technology/bemjson/current/#bemjson)
 
 <a name="templatebemjson"></a>
 
@@ -84,7 +84,7 @@ A template consists of:
 
 **See also**:
 
-* [BEM-XJST syntax](http://ru.bem.info/technology/bemhtml/current/templating/#unity) (Russian version only)
+* [BEM-XJST syntax](https://ru.bem.info/technology/bemhtml/current/templating/#unity) (Russian version only)
 
 <a name="moda"></a>
 
@@ -126,7 +126,7 @@ A BEM entity described by the current context is called the **context entity**.
 **See also**:
 
 * [The context fields](#context_field)
-* [Context-aided completion of BEM entities](http://ru.bem.info/technology/bemhtml/current/templating/#extensionbem) (Russian version only)
+* [Context-aided completion of BEM entities](https://ru.bem.info/technology/bemhtml/current/templating/#extensionbem) (Russian version only)
 
 <a name="standardmoda"></a>
 
@@ -151,7 +151,7 @@ In the sections that follow, modes are listed in the order in which they follow 
 
 <a name="empty_moda"></a>
 
-#### The "empty" Mode (`""`)
+#### The "empty" mode (`""`)
 
 *Template body value type: 'not used'*
 
@@ -324,7 +324,7 @@ Defining a template in the `js` mode (sub-predicate `js()`) only makes sense for
 
 **See also**:
 
-  * [JS implementation of the i-bem block](http://ru.bem.info/libs/bem-bl/current/desktop/i-bem/) (Russian version only)
+  * [JS implementation of the i-bem block](https://ru.bem.info/libs/bem-bl/current/desktop/i-bem/) (Russian version only)
 
 <a id="bem"></a>
 
@@ -647,7 +647,7 @@ All context fields can be divided into two categories:
 
 <a name="contextdependent"></a>
 
-#### Context-dependent Fields
+#### Context-dependent fields
 
 BEMHTML extends the set of context-dependent fields of BEM-XJST with the following ones:
 
@@ -729,7 +729,7 @@ In practice, the case of `this.isLast()` incorrect operation described above sho
 
 <a name="context_independent"></a>
 
-#### Context-independent Fields
+#### Context-independent fields
 
 All context-independent fields are grouped within the object `this._` and serve as auxiliary functions used when the template engine is running. The template author can use these functions in both template bodies and predicates.
 
@@ -752,6 +752,8 @@ BEMHTML extends the set of context-independent fields of BEM-XJST with the follo
 <a name="examples"></a>
 
 ### Examples and Recipes
+
+<a name="select_template"></a>
 
 #### Condition-based template selection
 
@@ -788,7 +790,7 @@ This expression won't be optimized during compilation, and will consequently imp
 
 **See also**:
 
-  * [Template syntax](http://ru.bem.info/technology/bemhtml/current/templating/#template) (Russian version only)
+  * [Template syntax](https://ru.bem.info/technology/bemhtml/current/templating/#template) (Russian version only)
 
 <a name="inheritage"></a>
 
@@ -796,7 +798,7 @@ This expression won't be optimized during compilation, and will consequently imp
 
 ##### Problem
 
-Two different templates are defined for the same BEM entity (`block b1`) at different [redifinition levels](http://bem.info/method/filesystem/). Each of the templates defines its content in the `content` mode.
+Two different templates are defined for the same BEM entity (`block b1`) at different [redifinition levels](https://bem.info/method/filesystem/). Each of the templates defines its content in the `content` mode.
 
 The content defined at the first level of redefinition should be **inherited** at the second level, and also some extra content should be added. An analogue of `<xsl:apply-imports/>` is required.
 
@@ -836,7 +838,7 @@ block('b1').content()([
 
 **See also**:
 
-  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyNext construction](https://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 
 <a name="parentblock"></a>
@@ -898,7 +900,7 @@ block('b-inner').def()
 
 **See also**:
 
-  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
+  * [The applyCtx construction](https://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 <a name="additionbem"></a>
 
@@ -961,9 +963,9 @@ block('box').match(!this.ctx._processed).content()(local({'ctx._processed':true}
 
 **See also**:
 
-  * [The apply construction](http://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
-  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
-  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
+  * [The apply construction](https://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
+  * [The applyNext construction](https://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyCtx construction](https://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 <a name="use_bem"></a>
 
@@ -1006,7 +1008,7 @@ block('menu')(
 **See also**:
 
   * [The `content` mode](#content)
-  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyNext construction](https://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 <a name="check_predicate"></a>
 
@@ -1075,10 +1077,10 @@ block('input')(
 
 ###See also
 
-* [BEMTREE: examples and recipes](http://bem.info/technology/bemtree/current/bemtree/#examples)
-* [Data templating in bem-core](http://ru.bem.info/libs/bem-core/current/templating/templating/) (Russian version only)
+* [BEMTREE: examples and recipes](https://bem.info/technology/bemtree/current/bemtree/#examples)
+* [Data templating in bem-core](https://ru.bem.info/libs/bem-core/current/templating/templating/) (Russian version only)
 
 ####In the community
 
-* [BEMTREE](http://en.bem.info/technology/bemtree/current/bemtree/)
-* [BEMJSON](http://en.bem.info/technology/bemjson/2.3.0/bemjson/)
+* [BEMTREE](https://bem.info/technology/bemtree/current/bemtree/)
+* [BEMJSON](https://bem.info/technology/bemjson/current/bemjson/)

--- a/common.docs/reference/reference.en.md
+++ b/common.docs/reference/reference.en.md
@@ -17,7 +17,7 @@ The reader is assumed to be familiar with:
 * JavaScript
 * CSS
 * BEM
-* BEMJSON
+* [BEMJSON](http://bem.info/technology/bemjson/current/bemjson/)
 
 **This document does not cover** the setup of the development environment, the template compilation procedure, or BEMJSON syntax.
 
@@ -26,6 +26,7 @@ The reader is assumed to be familiar with:
 ### BEMHTML Features
 
 <a name="arch"></a>
+
 #### Architecture
 
 BEMHTML templates are processed using the module [bem-xjst](http://bem.info/tools/templating-engines/bemxjst/) extended with logic from the BEMHTML default template – [i-bem.bemhtml](https://github.com/bem/bem-core/blob/v1/common.blocks/i-bem/i-bem.bemhtml).
@@ -35,7 +36,7 @@ BEMHTML-specific logic is implemented at `i-bem.bemhtml` template level. This de
 * the set of standard modes and in what order to call them;
 * available context fields.
 
-For a detailed description of BEMHTML's architecture, see the section [Architecture of BEMHTML and BEMTREE templates](http://ru.bem.info/technology/bemhtml/current/templating/#bemx_arch) of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (available only in Russian).
+For a detailed description of BEMHTML's architecture, see the section [Architecture of BEMHTML and BEMTREE templates](http://ru.bem.info/technology/bemhtml/current/templating/#bemx_arch) of the [Data templating in bem-core](http://ru.bem.info/technology/bemhtml/current/templating/) document (currently available only in Russian).
 
 <a name="uts"></a>
 ### Support of BEM-XJST templating
@@ -59,7 +60,7 @@ BEMHTML is based on JavaScript, so BEMJSON - a JavaScript data structure (object
 
 The purpose of the BEMHTML template engine is to convert an input BEM tree to an HTML document. It should be noted though that complex transformations of input data at template engine level are likely to compromise the flexibility and maintainability of the template engine, so it's best to keep things simple. In terms of template writing this means creating the most basic statements that map each available type of BEM entity with an appropriate HTML presentation.
 
-Therefore the input BEM tree structure should be **view**-oriented, to preclude the need to change blocks and elements or their order during the HTML tree generation process. Transforming the BEM tree into such a format should be done at back-end level, i.e. upstream - before the data hits the BEMTHML template engine (e.g. using the BEMTREE technology).
+Therefore the input BEM tree structure should be **view**-oriented, to preclude the need to change blocks and elements or their order during the HTML tree generation process. Transforming the BEM tree into such a format should be done at back-end level, i.e. upstream - before the data hits the BEMHTML template engine (e.g. using the [BEMTREE](http://bem.info/technology/bemtree/2.3.0/bemtree/) technology).
 
 The view-oriented data format is discussed in the news feed example, under the
 [Converting input data into view-oriented format](http://bem.info/technology/bemtree/current/bemtree/#bringing_input) problem in the **Examples and Recipes** section of the [BEMTREE](http://bem.info/technology/bemtree/current/bemtree/) document.
@@ -83,7 +84,7 @@ A template consists of:
 
 **See also**:
 
-* [BEMHTML syntax](#bemhtml)
+* [BEM-XJST syntax](http://ru.bem.info/technology/bemhtml/current/templating/#unity) (Russian version only)
 
 <a name="moda"></a>
 
@@ -125,7 +126,7 @@ A BEM entity described by the current context is called the **context entity**.
 **See also**:
 
 * [The context fields](#context_field)
-* [Context-aided completion of BEM entities](#extensionbem)
+* [Context-aided completion of BEM entities](http://ru.bem.info/technology/bemhtml/current/templating/#extensionbem) (Russian version only)
 
 <a name="standardmoda"></a>
 
@@ -188,7 +189,7 @@ The action performed in the empty mode depends on the element type of the contex
 
 Defining a template in the empty mode (sub-predicate `mode(this._mode === '')`) only makes sense if it is necessary to override the traversal process for the input tree.
 
-Calling templates in the empty mode (the `apply('')` construction in the template body) is necessary if the one-to-one mapping principle of "input BEM entity - output HTML element" has to be broken to enable generation of more than one element per input entity. Such a call is performed automatically when using the [`applyCtx` construction](#applyctx).
+Calling templates in the empty mode (the `apply('')` construction in the template body) is necessary if the one-to-one mapping principle of "input BEM entity - output HTML element" has to be broken to enable generation of more than one element per input entity. Such a call is performed automatically when using the `applyCtx` construction.
 
 **See also**:
 
@@ -323,7 +324,7 @@ Defining a template in the `js` mode (sub-predicate `js()`) only makes sense for
 
 **See also**:
 
-  * [JS-implementation of the i-bem block](http://bem.info/libs/bem-bl/current/desktop/i-bem/)
+  * [JS implementation of the i-bem block](http://ru.bem.info/libs/bem-bl/current/desktop/i-bem/) (Russian version only)
 
 <a id="bem"></a>
 
@@ -623,7 +624,7 @@ A template must be defined in the `content` mode (sub-predicate `content()`) if 
 **See also**:
 
 * [Inheritance](#inheritage)
-* [Adding BEM-entities for solving layout problems](#additionbem)
+* [Adding BEM entities to meet layout requirements](#additionbem)
 
 <a name="context_field"></a>
 
@@ -721,7 +722,7 @@ The `this.isLast ()` function, which is used to identify the last BEM entity amo
   )
 ```
 
-Such behavior is due to the fact that, for BEMTHML optimization purposes, a full preliminary traversal of the BEM tree is not performed.
+Such behavior is due to the fact that, for BEMHTML optimization purposes, a full preliminary traversal of the BEM tree is not performed.
 Therefore, in the above example, when block `b3` is being processed, the length of the array is already known (`b3` is not the last element) but it is not known yet that the last element is not a BEM entity and thus won't be receiving an index number.
 
 In practice, the case of `this.isLast()` incorrect operation described above shouldn't generate any errors, because the check for the first / last BEM entity is usually applied to automatically generated lists of entities, where it doesn't make sense to include data of other types.
@@ -787,7 +788,7 @@ This expression won't be optimized during compilation, and will consequently imp
 
 **See also**:
 
-  * [Syntax for Templates](#template)
+  * [Template syntax](http://ru.bem.info/technology/bemhtml/current/templating/#template) (Russian version only)
 
 <a name="inheritage"></a>
 
@@ -835,7 +836,7 @@ block('b1').content()([
 
 **See also**:
 
-  * [The applyNext construction](#applynext)
+  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 
 <a name="parentblock"></a>
@@ -897,7 +898,7 @@ block('b-inner').def()
 
 **See also**:
 
-  * [The applyCtx construction](#applyctx)
+  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 <a name="additionbem"></a>
 
@@ -960,9 +961,9 @@ block('box').match(!this.ctx._processed).content()(local({'ctx._processed':true}
 
 **See also**:
 
-  * [The `apply` construction](#apply)
-  * [The `applyNext` construction](#applynext)
-  * [The `applyCtx` construction](#applyctx)
+  * [The apply construction](http://ru.bem.info/technology/bemhtml/current/templating/#apply) (Russian version only)
+  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
+  * [The applyCtx construction](http://ru.bem.info/technology/bemhtml/current/templating/#applyctx) (Russian version only)
 
 <a name="use_bem"></a>
 
@@ -1004,8 +1005,8 @@ block('menu')(
 
 **See also**:
 
-  * [Mode content](#content)
-  * [Construction applyNext](#applynext)
+  * [The `content` mode](#content)
+  * [The applyNext construction](http://ru.bem.info/technology/bemhtml/current/templating/#applynext) (Russian version only)
 
 <a name="check_predicate"></a>
 
@@ -1069,3 +1070,15 @@ block('input')(
   ]
 ))
 ```
+
+<a name="links"></a>
+
+###See also
+
+* [BEMTREE: examples and recipes](http://bem.info/technology/bemtree/current/bemtree/#examples)
+* [Data templating in bem-core](http://ru.bem.info/libs/bem-core/current/templating/templating/) (Russian version only)
+
+####In the community
+
+* [BEMTREE](http://en.bem.info/technology/bemtree/current/bemtree/)
+* [BEMJSON](http://en.bem.info/technology/bemjson/2.3.0/bemjson/)


### PR DESCRIPTION
Sorry, forgot to update the URLs in the documents in the previous commit. Have now reviewed all the links to external documents and updated where appropriate: replaced with the English version if one now exists for the linked documentation, and added a "Russian version only"-type comment wherenever an explicit reference to another document is made (such as the "See also" note).
