### PR TITLE
ua: add support for ie11+

### DIFF
--- a/desktop.blocks/ua/ua.js
+++ b/desktop.blocks/ua/ua.js
@@ -11,6 +11,7 @@ var ua = navigator.userAgent.toLowerCase(),
         /(webkit)[ \/]([\w.]+)/.exec(ua) ||
         /(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
         /(msie) ([\w.]+)/.exec(ua) ||
+        /(msie)(?:.*? rv:([\w.]+))/.exec(ua.replace('trident', 'msie')) ||
         ua.indexOf('compatible') < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua) ||
         [],
     matched = {


### PR DESCRIPTION
Hey!
IE since 11 version doesn't match previous regexp. Moreover, it simulates useragent like FF 11.

```
IE 11: "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko"
FF 35: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:35.0) Gecko/20100101 Firefox/35.0" 
```

Thus, our current implementation of `ua` recognizes IE 11 as FF 11.

//cc @dfilatov @narqo 
