### PR TITLE
page__conditional-comment: Implement template

### DIFF
--- a/desktop.blocks/page/__conditional-comment/page__conditional-comment.bemhtml
+++ b/desktop.blocks/page/__conditional-comment/page__conditional-comment.bemhtml
@@ -1,0 +1,23 @@
+block('page').elem('conditional-comment')(
+    tag()(false),
+
+    content()(function() {
+        var ctx = this.ctx,
+            cond = ctx.condition
+                .replace('<', 'lt')
+                .replace('>', 'gt')
+                .replace('=', 'e'),
+            hasNegation = cond.indexOf('!') > -1,
+            includeOthers = ctx.msieOnly === false,
+            hasNegationOrIncludeOthers = hasNegation || includeOthers;
+
+        return [
+            '<!--[if ' + cond + ']>',
+            includeOthers? '<!' : '',
+            hasNegationOrIncludeOthers? '-->' : '',
+            applyNext(),
+            hasNegationOrIncludeOthers? '<!--' : '',
+            '<![endif]-->'
+        ];
+    })
+);

--- a/desktop.blocks/page/__conditional-comment/page__conditional-comment.bh.js
+++ b/desktop.blocks/page/__conditional-comment/page__conditional-comment.bh.js
@@ -1,0 +1,24 @@
+module.exports = function(bh) {
+
+    bh.match('page__conditional-comment', function(ctx, json) {
+        ctx.tag(false);
+
+        var cond = json.condition
+                .replace('<', 'lt')
+                .replace('>', 'gt')
+                .replace('=', 'e'),
+            hasNegation = cond.indexOf('!') > -1,
+            includeOthers = json.msieOnly === false,
+            hasNegationOrIncludeOthers = hasNegation || includeOthers;
+
+        return [
+            '<!--[if ' + cond + ']>',
+            includeOthers? '<!' : '',
+            hasNegationOrIncludeOthers? '-->' : '',
+            json,
+            hasNegationOrIncludeOthers? '<!--' : '',
+            '<![endif]-->'
+        ];
+    });
+
+};

--- a/desktop.blocks/page/__conditional-comment/page__conditional-comment.ru.md
+++ b/desktop.blocks/page/__conditional-comment/page__conditional-comment.ru.md
@@ -1,0 +1,31 @@
+```javascript
+({
+    block : 'page',
+    title : 'page__conditional-comments',
+    head : [
+        {
+            elem : 'conditional-comment',
+            condition : '<= IE 8',
+            content : { elem : 'css', url : '_page.ie.css' }
+        },
+        {
+            elem : 'conditional-comment',
+            condition : '! IE',
+            content : 'Not for IE'
+        },
+        {
+            elem : 'conditional-comment',
+            condition : '> IE 8',
+            msieOnly : false,
+            content : 'For IE9+ and all other browsers'
+        }
+    ],
+    scripts : [
+        {
+            elem : 'conditional-comment',
+            condition : 'lte IE 8',
+            content : { elem : 'js', url : '//yastatic.net/es5-shims/0.0.1/es5-shims.min.js' }
+        }
+    ]
+})
+```

--- a/desktop.blocks/page/page.deps.js
+++ b/desktop.blocks/page/page.deps.js
@@ -1,0 +1,6 @@
+({
+    tech : 'tmpl-spec.js',
+    shouldDeps : {
+        elems : ['conditional-comment']
+    }
+})

--- a/desktop.blocks/page/page.tmpl-specs/40-css-ie.html
+++ b/desktop.blocks/page/page.tmpl-specs/40-css-ie.html
@@ -10,17 +10,10 @@
     <!--[if gt IE 9]><!-->
         <link rel="stylesheet" href="_30-css-ie.css"/>
     <!--<![endif]-->
-    <!--[if IE 6]>
-        <link rel="stylesheet" href="_30-css-ie.ie6.css"/>
-    <![endif]-->
-    <!--[if IE 7]>
-        <link rel="stylesheet" href="_30-css-ie.ie7.css"/><![endif]-->
-    <!--[if IE 8]>
-        <link rel="stylesheet" href="_30-css-ie.ie8.css"/>
-    <![endif]-->
-    <!--[if IE 9]>
-        <link rel="stylesheet" href="_30-css-ie.ie9.css"/>
-    <![endif]-->
+    <!--[if IE 6]><link rel="stylesheet" href="_30-css-ie.ie6.css"/><![endif]-->
+    <!--[if IE 7]><link rel="stylesheet" href="_30-css-ie.ie7.css"/><![endif]-->
+    <!--[if IE 8]><link rel="stylesheet" href="_30-css-ie.ie8.css"/><![endif]-->
+    <!--[if IE 9]><link rel="stylesheet" href="_30-css-ie.ie9.css"/><![endif]-->
 </head>
 <body class="page"></body>
 </html>

--- a/desktop.blocks/page/page.tmpl-specs/50-conditions.html
+++ b/desktop.blocks/page/page.tmpl-specs/50-conditions.html
@@ -7,9 +7,7 @@
     <script>
         (function(e,c){e[c]=e[c].replace(/(ua_js_)no/g,"$1yes");})(document.documentElement,"className");
     </script>
-    <!--[if lt IE 9]>
-        <script src="//yastatic.net/es5-shims/0.0.1/es5-shims.min.js"></script>
-    <![endif]-->
+    <!--[if lt IE 9]><script src="//yastatic.net/es5-shims/0.0.1/es5-shims.min.js"></script><![endif]-->
 </head>
 <body class="page"></body>
 </html>

--- a/desktop.blocks/page/page.tmpl-specs/60-conditional-comments.bemjson.js
+++ b/desktop.blocks/page/page.tmpl-specs/60-conditional-comments.bemjson.js
@@ -1,0 +1,29 @@
+({
+    block : 'page',
+    title : 'page__conditional-comments',
+    head : [
+        {
+            elem : 'conditional-comment',
+            condition : '<= IE 8',
+            content : { elem : 'css', url : '_60-conditional-comment.ie.css' }
+        },
+        {
+            elem : 'conditional-comment',
+            condition : '! IE',
+            content : 'Not for IE'
+        },
+        {
+            elem : 'conditional-comment',
+            condition : '> IE 8',
+            msieOnly : false,
+            content : 'For IE9+ and all other browsers'
+        }
+    ],
+    scripts : [
+        {
+            elem : 'conditional-comment',
+            condition : 'lte IE 8',
+            content : { elem : 'js', url : '//yastatic.net/es5-shims/0.0.1/es5-shims.min.js' }
+        }
+    ]
+})

--- a/desktop.blocks/page/page.tmpl-specs/60-conditional-comments.html
+++ b/desktop.blocks/page/page.tmpl-specs/60-conditional-comments.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html class="ua_js_no">
+<head>
+<meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+<meta charset="utf-8"/>
+<title>page__conditional-comments</title>
+<script>(function(e,c){e[c]=e[c].replace(/(ua_js_)no/g,"$1yes");})(document.documentElement,"className");</script>
+<!--[if lte IE 8]><link rel="stylesheet" href="_60-conditional-comment.ie.css"/><![endif]-->
+<!--[if ! IE]>-->Not for IE<!--<![endif]-->
+<!--[if gt IE 8]><!-->For IE9+ and all other browsers<!--<![endif]-->
+</head>
+<body class="page">
+<!--[if lte IE 8]><script src="//yastatic.net/es5-shims/0.0.1/es5-shims.min.js"></script><![endif]-->
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "enb-bem-docs": "0.7.3",
     "enb-bem-examples": "0.5.9",
     "enb-bem-specs": "0.5.5",
-    "enb-bem-tmpl-specs": "0.6.1",
+    "enb-bem-tmpl-specs": "0.10.0",
     "enb-bemxjst": "1.3.3",
     "enb-bh": "0.4.0",
     "enb-borschik": "^1.5.0",


### PR DESCRIPTION
1. Updated `enb-bem-tmpl-specs` to check HTML comments
2. Fixed old reference HTMLs after [1]
3. Implemented templates as discussed in #551 but with two additions:
   - `includeOthers` param to generate CC which works in specified IE versions and all other browsers
   - possibility to specify versions both with `lte` and `<=` syntax
4. Wrote basic examples

cc @sipayRT @hcodes @veged 
