### PR TITLE
i-bem: use resetApplyNext before entering `content`

### DIFF
--- a/common.blocks/i-bem/i-bem.bemhtml
+++ b/common.blocks/i-bem/i-bem.bemhtml
@@ -11,7 +11,8 @@ var undef,
     },
     SHORT_TAGS = { // хэш для быстрого определения, является ли тэг коротким
         area : 1, base : 1, br : 1, col : 1, command : 1, embed : 1, hr : 1, img : 1,
-        input : 1, keygen : 1, link : 1, meta : 1, param : 1, source : 1, wbr : 1 };
+        input : 1, keygen : 1, link : 1, meta : 1, param : 1, source : 1, wbr : 1 },
+    resetApplyNext = context.resetApplyNext || function() {};
 
 (function(BEM, undefined) {
 
@@ -179,6 +180,7 @@ function BEMContext(context, apply_) {
     this.elem = undef;
     this.mods = undef;
     this.elemMods = undef;
+    this._resetApplyNext = resetApplyNext;
 }
 
 BEMContext.prototype.isArray = isArray;
@@ -459,6 +461,7 @@ def()(function() {
 
             var content = apply('content');
             if(content || content === 0) {
+                this._resetApplyNext(this);
                 isBEM = vBlock || this.elem;
                 apply('', {
                     _notNewList : false,

--- a/common.blocks/i-bem/i-bem.bemtree
+++ b/common.blocks/i-bem/i-bem.bemtree
@@ -15,7 +15,8 @@ var undef,
             r = new RegExp(r, 'g');
             return function(s) { return ('' + s).replace(r, f); };
         };
-    })();
+    })(),
+    resetApplyNext = context.resetApplyNext || function() {};
 
 context.BEMContext = BEMContext;
 
@@ -32,6 +33,7 @@ function BEMContext(context, apply_) {
     this.elem = undef;
     this.mods = undef;
     this.elemMods = undef;
+    this._resetApplyNext = resetApplyNext;
 }
 
 BEMContext.prototype.isArray = isArray;
@@ -152,6 +154,7 @@ match(this._mode === '')(
 def()(function() {
     var content = apply('content');
     if(content || content === 0) {
+        this._resetApplyNext(this);
         this.ctx.content = apply('', { ctx : content });
     }
     return this.ctx;

--- a/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.bemhtml
+++ b/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.bemhtml
@@ -1,0 +1,5 @@
+block('b1').def()(function() {
+  return local({ 'ctx.tag': 'span' })(function() {
+    return applyNext();
+  });
+});

--- a/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.html
+++ b/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.html
@@ -1,0 +1,1 @@
+<span class="b1"><span class="b1"></span></span>

--- a/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.json
+++ b/common.blocks/i-bem/i-bem.test.bemhtml/files/i-bem/reset-apply-next.json
@@ -1,0 +1,6 @@
+{
+  "block": "b1",
+  "content": {
+    "block": "b1"
+  }
+}

--- a/common.blocks/i-bem/i-bem.test.bemhtml/i-bem-test.js
+++ b/common.blocks/i-bem/i-bem.test.bemhtml/i-bem-test.js
@@ -49,4 +49,5 @@ suite('i-bem block and others', function() {
   unit('mix with same block bem-core/804', 'gh-core-804');
   unit('nested mix as object bem-core/873', 'gh-core-873');
   unit('string mix', 'string-mix');
+  unit('reset apply next when entering content', 'reset-apply-next');
 });

--- a/common.blocks/page/page.bemhtml
+++ b/common.blocks/page/page.bemhtml
@@ -16,8 +16,15 @@ block('page')(
                             elem : 'head',
                             content : [
                                 { tag : 'meta', attrs : { charset : 'utf-8' } },
+                                ctx.uaCompatible === false? '' : {
+                                    tag : 'meta',
+                                    attrs : {
+                                        'http-equiv' : 'X-UA-Compatible',
+                                        content : ctx.uaCompatible || 'IE=edge'
+                                    }
+                                },
                                 { tag : 'title', content : ctx.title },
-                                { block : 'ua' },
+                                { block : 'ua', attrs : { nonce : ctx.nonce } },
                                 ctx.head,
                                 ctx.styles,
                                 ctx.favicon? { elem : 'favicon', url : ctx.favicon } : ''

--- a/common.blocks/page/page.bemhtml
+++ b/common.blocks/page/page.bemhtml
@@ -1,37 +1,33 @@
 block('page')(
 
-    def()(function() {
+    def().match(function() { return !this._pageInit; })(function() {
         var ctx = this.ctx;
         this._nonceCsp = ctx.nonce;
 
-        return applyCtx([
-            ctx.doctype || '<!DOCTYPE html>',
-            {
-                tag : 'html',
-                cls : 'ua_js_no',
-                content : [
-                    {
-                        elem : 'head',
-                        content : [
-                            { tag : 'meta', attrs : { charset : 'utf-8' } },
-                            ctx.uaCompatible === false? '' : {
-                                tag : 'meta',
-                                attrs : {
-                                    'http-equiv' : 'X-UA-Compatible',
-                                    content : ctx.uaCompatible || 'IE=edge'
-                                }
-                            },
-                            { tag : 'title', content : ctx.title },
-                            { block : 'ua', attrs : { nonce : ctx.nonce } },
-                            ctx.head,
-                            ctx.styles,
-                            ctx.favicon? { elem : 'favicon', url : ctx.favicon } : ''
-                        ]
-                    },
-                    ctx
-                ]
-            }
-        ]);
+        // TODO(indunty): remove local after bem/bem-xjst#50
+        return local({ _pageInit : true })(function() {
+            return applyCtx([
+                ctx.doctype || '<!DOCTYPE html>',
+                {
+                    tag : 'html',
+                    cls : 'ua_js_no',
+                    content : [
+                        {
+                            elem : 'head',
+                            content : [
+                                { tag : 'meta', attrs : { charset : 'utf-8' } },
+                                { tag : 'title', content : ctx.title },
+                                { block : 'ua' },
+                                ctx.head,
+                                ctx.styles,
+                                ctx.favicon? { elem : 'favicon', url : ctx.favicon } : ''
+                            ]
+                        },
+                        ctx
+                    ]
+                }
+            ]);
+        });
     }),
 
     tag()('body'),


### PR DESCRIPTION
Skip all `applyNext()` flags before entering the `content` to support
recursive blocks with `applyNext()` (see test).

**Depends on: https://github.com/veged/xjst/pull/41**
