### PR TITLE
Attribute escaping optimization #961

### DIFF
--- a/common.blocks/i-bem/i-bem.bemhtml
+++ b/common.blocks/i-bem/i-bem.bemhtml
@@ -226,7 +226,7 @@ BEMContext.prototype.identify = (function() {
 })();
 
 BEMContext.prototype.xmlEscape = buildEscape('[&<>]');
-BEMContext.prototype.attrEscape = buildEscape('["&<>]');
+BEMContext.prototype.attrEscape = buildEscape('["&]');
 BEMContext.prototype.jsAttrEscape = buildEscape('[\'&]');
 
 BEMContext.prototype.BEM = BEM_;


### PR DESCRIPTION
Fixes "Attribute escaping optimization #961".

All tests are fine.
