### PR TITLE
Improve BEMTREE error handling

### DIFF
--- a/common.blocks/i-bem/i-bem.bemtree
+++ b/common.blocks/i-bem/i-bem.bemtree
@@ -3,10 +3,12 @@
 oninit(function(exports, context) {
 
 var undef,
-    BEM_ = {},
     toString = Object.prototype.toString,
     isArray = Array.isArray || function(obj) {
         return toString.call(obj) === '[object Array]';
+    },
+    isFunction = function(obj) {
+        return typeof obj === 'function';
     },
     buildEscape = (function() {
         var ts = { '"' : '&quot;', '&' : '&amp;', '<' : '&lt;', '>' : '&gt;' },
@@ -69,27 +71,53 @@ BEMContext.prototype.generateId = function generateId() {
     return this.identify(this.ctx);
 };
 
-BEMContext.prototype.doAsync = function doAsync(fn) {
+/**
+ * @param {Function|Promise} fn
+ * @param {Function} [onFulfilled]
+ * @param {Function} [onRejected]
+ * @param {Object} [context]
+ * @returns {vow:Promise}
+ */
+BEMContext.prototype.doAsync = function doAsync(fn, onFulfilled, onRejected, context) {
+    if(onFulfilled && !isFunction(onFulfilled)) {
+        context = onFulfilled;
+        onFulfilled = undef;
+    } else if(onRejected && !isFunction(onRejected)) {
+        context = onRejected;
+        onRejected = undef;
+    }
+    context = context || this;
+
     var mode  = this._mode,
         ctx   = this.ctx,
         block = this.block,
         elem  = this.elem,
         mods  = this.mods,
         elemMods = this.elemMods,
-        promise = Vow.invoke(fn);
+        _this = this,
+        restore = function(response) {
+            _this._mode = mode;
+            _this.ctx   = ctx;
+            _this.block = block;
+            _this.elem  = elem;
+            _this.mods  = mods;
+            _this.elemMods = elemMods;
+            return response;
+        },
+        promise = isFunction(fn) ? Vow.invoke(fn, context) : fn;
+
+    if(onFulfilled) {
+        promise = onRejected ? promise
+            .then(function(response) {
+                return onFulfilled.call(this, restore(response));
+            }, function(response) {
+                return onRejected.call(this, restore(response));
+            }, context) : promise.then(restore).then(onFulfilled, context);
+    }
 
     this.__queue.push(promise);
 
-    promise.always(function() {
-        this._mode = mode;
-        this.ctx   = ctx;
-        this.block = block;
-        this.elem  = elem;
-        this.mods  = mods;
-        this.elemMods = elemMods;
-    }.bind(this));
-
-    return promise;
+    return promise.always(restore);
 };
 
 // Wrap xjst's apply and export our own
@@ -99,8 +127,8 @@ exports.apply = BEMContext.applyAsync = function BEMContext_applyAsync(context) 
     ctx._buf = ctx.apply();
     return Vow
         .allResolved(ctx.__queue)
-        .always(function() {
-            return ctx._buf;
+        .always(function(promise) {
+            return [ctx._buf, promise.valueOf()];
         });
 };
 


### PR DESCRIPTION
For #594
Though I still think that force users to use `BEMTREE.apply().spread()` is not a good solution. I think, force users to handle errors is better choice.
