### PR TITLE
Use container infrastructure to run builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - '0.10'
 
+# sudo=false to run builds inside container infrastructure
+# see https://github.com/bem/bem-components/issues/1528
+sudo: false
+
 env:
   global:
     - secure: "EocST8MkGsiC8SU91QH8/Cz71ehcCHW6+VEeG6RalauYpB56O77p9d4gwhIk5J7uFyRHyEHJConjN/JM74WSY1s2jvVn2AZTeyhVgacxPFjaRZyRnDMjlyGEUfABfaKggpFvtiCzYKh/Y0jYDK27beDXdTp+nAcZQDAyFpjL6JU="


### PR DESCRIPTION
As we don't run run gemini tests in bem-core, we can use travis container infrastructure to run our builds.

It seems that this helps to fix the problem described in bem/bem-components#1528.
