### PR TITLE
Add npm-shrinkwrap.json to lock npm dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,6480 @@
+{
+  "name": "bem-core",
+  "version": "2.5.1",
+  "dependencies": {
+    "bem": {
+      "version": "0.9.0",
+      "from": "bem@>=0.9.0 <0.10.0",
+      "dependencies": {
+        "coa": {
+          "version": "0.4.1",
+          "from": "coa@0.4.1"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@0.9.7"
+        },
+        "qq": {
+          "version": "0.3.5",
+          "from": "qq@0.3.5",
+          "dependencies": {
+            "q": {
+              "version": "0.8.4",
+              "from": "q@0.8.4"
+            }
+          }
+        },
+        "q-io": {
+          "version": "1.10.9",
+          "from": "q-io@1.10.9",
+          "dependencies": {
+            "qs": {
+              "version": "0.1.0",
+              "from": "qs@0.1.0"
+            },
+            "url2": {
+              "version": "0.0.0",
+              "from": "url2@0.0.0"
+            },
+            "mimeparse": {
+              "version": "0.1.4",
+              "from": "mimeparse@0.1.4"
+            },
+            "collections": {
+              "version": "0.2.2",
+              "from": "collections@0.2.2",
+              "dependencies": {
+                "weak-map": {
+                  "version": "1.0.0",
+                  "from": "weak-map@1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@1.2.11"
+        },
+        "lodash": {
+          "version": "2.2.1",
+          "from": "lodash@2.2.1"
+        },
+        "inherit": {
+          "version": "1.0.4",
+          "from": "inherit@1.0.4"
+        },
+        "borschik": {
+          "version": "1.2.0",
+          "from": "borschik@1.2.0",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2.5.0"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0"
+                }
+              }
+            },
+            "coa": {
+              "version": "0.4.0",
+              "from": "coa@0.4.0"
+            },
+            "inherit": {
+              "version": "2.2.1",
+              "from": "inherit@2.2.1"
+            },
+            "vow": {
+              "version": "0.3.13",
+              "from": "vow@0.3.13"
+            },
+            "vow-fs": {
+              "version": "0.3.2",
+              "from": "vow-fs@0.3.2",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "node-uuid@1.4.0"
+                },
+                "vow": {
+                  "version": "0.4.4",
+                  "from": "vow@0.4.4"
+                },
+                "vow-queue": {
+                  "version": "0.3.1",
+                  "from": "vow-queue@0.3.1"
+                },
+                "glob": {
+                  "version": "3.2.8",
+                  "from": "glob@3.2.8",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "csso": {
+              "version": "1.3.11",
+              "from": "csso@1.3.11"
+            },
+            "uglify-js": {
+              "version": "2.4.15",
+              "from": "uglify-js@2.4.15",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@0.2.10"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@0.1.0"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@0.3.7",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "borschik-tech-cleancss": {
+          "version": "1.0.0",
+          "from": "borschik-tech-cleancss@1.0.0",
+          "dependencies": {
+            "clean-css": {
+              "version": "2.2.12",
+              "from": "clean-css@2.2.12",
+              "dependencies": {
+                "commander": {
+                  "version": "2.2.0",
+                  "from": "commander@2.2.0"
+                }
+              }
+            }
+          }
+        },
+        "apw": {
+          "version": "0.3.14",
+          "from": "apw@0.3.14"
+        },
+        "winston": {
+          "version": "0.7.3",
+          "from": "winston@0.7.3",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@0.2.10"
+            },
+            "cycle": {
+              "version": "1.0.3",
+              "from": "cycle@1.0.3"
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "from": "eyes@0.1.8"
+            },
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@0.3.0"
+            },
+            "request": {
+              "version": "2.16.6",
+              "from": "request@2.16.6",
+              "dependencies": {
+                "form-data": {
+                  "version": "0.0.10",
+                  "from": "form-data@0.0.10",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.5",
+                      "from": "combined-stream@0.0.5",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "0.10.2",
+                  "from": "hawk@0.10.2",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.7.6",
+                      "from": "hoek@0.7.6"
+                    },
+                    "boom": {
+                      "version": "0.3.8",
+                      "from": "boom@0.3.8"
+                    },
+                    "cryptiles": {
+                      "version": "0.1.3",
+                      "from": "cryptiles@0.1.3"
+                    },
+                    "sntp": {
+                      "version": "0.1.4",
+                      "from": "sntp@0.1.4"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.1",
+                  "from": "node-uuid@1.4.1"
+                },
+                "cookie-jar": {
+                  "version": "0.2.0",
+                  "from": "cookie-jar@0.2.0"
+                },
+                "aws-sign": {
+                  "version": "0.2.0",
+                  "from": "aws-sign@0.2.0"
+                },
+                "oauth-sign": {
+                  "version": "0.2.0",
+                  "from": "oauth-sign@0.2.0"
+                },
+                "forever-agent": {
+                  "version": "0.2.0",
+                  "from": "forever-agent@0.2.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.2.0",
+                  "from": "tunnel-agent@0.2.0"
+                },
+                "json-stringify-safe": {
+                  "version": "3.0.0",
+                  "from": "json-stringify-safe@3.0.0"
+                },
+                "qs": {
+                  "version": "0.5.6",
+                  "from": "qs@0.5.6"
+                }
+              }
+            },
+            "stack-trace": {
+              "version": "0.0.9",
+              "from": "stack-trace@0.0.9"
+            }
+          }
+        },
+        "dom-js": {
+          "version": "0.0.9",
+          "from": "dom-js@0.0.9",
+          "dependencies": {
+            "sax": {
+              "version": "0.6.0",
+              "from": "sax@0.6.0"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5"
+        },
+        "node.extend": {
+          "version": "1.0.10",
+          "from": "node.extend@1.0.10",
+          "dependencies": {
+            "is": {
+              "version": "0.3.0",
+              "from": "is@0.3.0"
+            }
+          }
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@0.6.2"
+        },
+        "benchmark": {
+          "version": "1.0.0",
+          "from": "benchmark@1.0.0"
+        },
+        "cli-table": {
+          "version": "0.3.0",
+          "from": "cli-table@0.3.0"
+        }
+      }
+    },
+    "bem-environ": {
+      "version": "1.4.0",
+      "from": "bem-environ@>=1.4.0 <1.5.0"
+    },
+    "bem-naming": {
+      "version": "0.5.1",
+      "from": "bem-naming@0.5.1"
+    },
+    "bem-xjst": {
+      "version": "0.9.0",
+      "from": "bem-xjst@0.9.0",
+      "dependencies": {
+        "coa": {
+          "version": "0.3.9",
+          "from": "coa@>=0.3.9 <0.4.0",
+          "dependencies": {
+            "q": {
+              "version": "0.8.12",
+              "from": "q@>=0.8.10 <0.9.0"
+            }
+          }
+        },
+        "esprima": {
+          "version": "1.1.1",
+          "from": "esprima@>=1.1.1 <1.2.0"
+        },
+        "estraverse": {
+          "version": "1.5.1",
+          "from": "estraverse@>=1.5.0 <1.6.0"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@>=0.9.3 <0.10.0"
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@>=2.3.2 <2.4.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.7 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.5 <0.4.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                }
+              }
+            }
+          }
+        },
+        "xjst": {
+          "version": "1.5.0",
+          "from": "xjst@>=1.5.0 <1.6.0",
+          "dependencies": {
+            "coa": {
+              "version": "0.4.1",
+              "from": "coa@>=0.4.0 <0.5.0"
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.4.0 <2.5.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bemhtml-compat": {
+      "version": "0.1.2",
+      "from": "bemhtml-compat@>=0.1.2 <0.2.0",
+      "dependencies": {
+        "ometajs": {
+          "version": "3.2.4",
+          "from": "ometajs@>=3.2.4 <3.3.0",
+          "dependencies": {
+            "coa": {
+              "version": "0.3.9",
+              "from": "coa@>=0.3.0 <0.4.0"
+            },
+            "q": {
+              "version": "0.8.12",
+              "from": "q@>=0.8.0 <0.9.0"
+            },
+            "uglify-js": {
+              "version": "1.3.5",
+              "from": "uglify-js@>=1.3.0 <1.4.0"
+            }
+          }
+        },
+        "xjst": {
+          "version": "0.4.26",
+          "from": "xjst@>=0.4.21 <0.5.0",
+          "dependencies": {
+            "coa": {
+              "version": "0.3.9",
+              "from": "coa@>=0.3.8 <0.4.0"
+            },
+            "ometajs": {
+              "version": "3.3.8",
+              "from": "ometajs@>=3.3.4 <3.4.0"
+            },
+            "q": {
+              "version": "0.8.12",
+              "from": "q@>=0.8.10 <0.9.0"
+            },
+            "uglify-js": {
+              "version": "1.3.5",
+              "from": "uglify-js@>=1.3.0 <1.4.0"
+            },
+            "spoon": {
+              "version": "0.1.10",
+              "from": "spoon@>=0.1.10 <0.2.0",
+              "dependencies": {
+                "escodegen": {
+                  "version": "0.0.28",
+                  "from": "escodegen@>=0.0.15 <0.1.0",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.3.2",
+                      "from": "estraverse@>=1.3.0 <1.4.0"
+                    },
+                    "source-map": {
+                      "version": "0.4.2",
+                      "from": "source-map@>=0.1.2",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "amdefine@>=0.0.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                "estraverse": {
+                  "version": "0.0.4",
+                  "from": "estraverse@>=0.0.4 <0.1.0"
+                }
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@>=1.0.2 <1.1.0"
+        }
+      }
+    },
+    "bh": {
+      "version": "3.3.0",
+      "from": "bh@>=1.0.0 <4.0.0"
+    },
+    "borschik": {
+      "version": "1.3.2",
+      "from": "borschik@>=1.3.2 <2.0.0",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@0.2.14",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0"
+            }
+          }
+        },
+        "coa": {
+          "version": "0.4.0",
+          "from": "coa@0.4.0",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@>=0.9.6 <0.10.0"
+            }
+          }
+        },
+        "inherit": {
+          "version": "2.2.1",
+          "from": "inherit@2.2.1"
+        },
+        "vow": {
+          "version": "0.3.13",
+          "from": "vow@0.3.13"
+        },
+        "vow-fs": {
+          "version": "0.3.2",
+          "from": "vow-fs@0.3.2",
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.0",
+              "from": "node-uuid@1.4.0"
+            },
+            "vow": {
+              "version": "0.4.4",
+              "from": "vow@0.4.4"
+            },
+            "vow-queue": {
+              "version": "0.3.1",
+              "from": "vow-queue@0.3.1"
+            }
+          }
+        },
+        "csso": {
+          "version": "1.3.11",
+          "from": "csso@1.3.11"
+        },
+        "uglify-js": {
+          "version": "2.4.15",
+          "from": "uglify-js@2.4.15",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.5 <0.4.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+            }
+          }
+        }
+      }
+    },
+    "borschik-tech-cleancss": {
+      "version": "2.0.1",
+      "from": "borschik-tech-cleancss@2.0.1",
+      "dependencies": {
+        "clean-css": {
+          "version": "3.0.10",
+          "from": "clean-css@3.0.10",
+          "dependencies": {
+            "commander": {
+              "version": "2.5.1",
+              "from": "commander@>=2.5.0 <2.6.0"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.43 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bower": {
+      "version": "1.3.12",
+      "from": "bower@1.3.12",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.7",
+          "from": "abbrev@>=1.0.4 <1.1.0"
+        },
+        "archy": {
+          "version": "0.0.2",
+          "from": "archy@0.0.2"
+        },
+        "bower-config": {
+          "version": "0.5.2",
+          "from": "bower-config@>=0.5.2 <0.6.0",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "bower-json@>=0.4.0 <0.5.0",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "from": "deep-extend@>=0.2.5 <0.3.0"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "intersect@>=0.0.3 <0.1.0"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "bower-logger@>=0.2.2 <0.3.0"
+        },
+        "bower-registry-client": {
+          "version": "0.2.4",
+          "from": "bower-registry-client@>=0.2.0 <0.3.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.8 <0.3.0"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "lru-cache@>=2.3.0 <2.4.0"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@>=2.51.0 <2.52.0",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@>=0.8.0 <0.9.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0"
+                    },
+                    "mime-types": {
+                      "version": "2.0.14",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "request-replay@>=0.2.0 <0.3.0"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.0",
+          "from": "cardinal@0.4.0",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "redeyed@>=0.4.0 <0.5.0",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.4 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.5.0",
+          "from": "chalk@0.5.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "chmodr@0.1.0"
+        },
+        "decompress-zip": {
+          "version": "0.0.8",
+          "from": "decompress-zip@0.0.8",
+          "dependencies": {
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "mkpath@>=0.1.0 <0.2.0"
+            },
+            "binary": {
+              "version": "0.3.0",
+              "from": "binary@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "chainsaw@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "traverse@>=0.3.0 <0.4.0"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "buffers@>=0.1.1 <0.2.0"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.2",
+              "from": "touch@0.0.2",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "nopt@>=1.0.10 <1.1.0"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.8 <1.2.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            },
+            "nopt": {
+              "version": "2.2.1",
+              "from": "nopt@>=2.2.0 <2.3.0"
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.6",
+          "from": "fstream@>=1.0.2 <1.1.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "fstream-ignore@>=1.0.1 <1.1.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "4.0.6",
+          "from": "glob@>=4.0.2 <4.1.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "graceful-fs@>=3.0.1 <3.1.0"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "handlebars@>=2.0.0 <2.1.0",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.7.1",
+          "from": "inquirer@0.7.1",
+          "dependencies": {
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@>=0.3.8 <0.4.0",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.3.2 <2.0.0"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.3",
+              "from": "rx@>=2.2.27 <3.0.0"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.4 <2.4.0"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.4.3",
+          "from": "insight@0.4.3",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.3.1",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.2 <1.1.0",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.9.3",
+                          "from": "lodash@>=3.2.0 <4.0.0"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.2.0",
+                      "from": "esprima@>=2.2.0 <2.3.0"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.6.0",
+              "from": "inquirer@>=0.6.0 <0.7.0",
+              "dependencies": {
+                "cli-color": {
+                  "version": "0.3.3",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    },
+                    "memoizee": {
+                      "version": "0.3.8",
+                      "from": "memoizee@>=0.3.8 <0.4.0",
+                      "dependencies": {
+                        "es6-weak-map": {
+                          "version": "0.1.4",
+                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.3 <0.2.0"
+                            },
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0"
+                            }
+                          }
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "event-emitter@>=0.3.1 <0.4.0"
+                        },
+                        "lru-queue": {
+                          "version": "0.1.0",
+                          "from": "lru-queue@>=0.1.0 <0.2.0"
+                        },
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0"
+                        }
+                      }
+                    },
+                    "timers-ext": {
+                      "version": "0.1.0",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <2.5.0"
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@0.0.4"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "readline2@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rx": {
+                  "version": "2.5.3",
+                  "from": "rx@>=2.2.27 <3.0.0"
+                },
+                "through": {
+                  "version": "2.3.7",
+                  "from": "through@>=2.3.4 <2.4.0"
+                }
+              }
+            },
+            "lodash.debounce": {
+              "version": "2.4.1",
+              "from": "lodash.debounce@>=2.4.1 <3.0.0",
+              "dependencies": {
+                "lodash.isfunction": {
+                  "version": "2.4.1",
+                  "from": "lodash.isfunction@>=2.4.1 <2.5.0"
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0"
+                    }
+                  }
+                },
+                "lodash.now": {
+                  "version": "2.4.1",
+                  "from": "lodash.now@>=2.4.1 <2.5.0",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "1.0.0",
+              "from": "object-assign@>=1.0.0 <2.0.0"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "os-name@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.1.0",
+                  "from": "osx-release@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "win-release@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.1 <0.13.0",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "is-root@>=1.0.0 <1.1.0"
+        },
+        "junk": {
+          "version": "1.0.1",
+          "from": "junk@>=1.0.0 <1.1.0"
+        },
+        "lockfile": {
+          "version": "1.0.1",
+          "from": "lockfile@>=1.0.0 <1.1.0"
+        },
+        "lru-cache": {
+          "version": "2.5.2",
+          "from": "lru-cache@>=2.5.0 <2.6.0"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "mkdirp@0.5.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.9.1",
+          "from": "mout@>=0.9.0 <0.10.0"
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "nopt@>=3.0.1 <3.1.0"
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "opn@>=1.0.0 <1.1.0"
+        },
+        "osenv": {
+          "version": "0.1.0",
+          "from": "osenv@0.1.0"
+        },
+        "p-throttler": {
+          "version": "0.1.0",
+          "from": "p-throttler@0.1.0",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "q@>=0.9.2 <0.10.0"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "promptly@0.2.0",
+          "dependencies": {
+            "read": {
+              "version": "1.0.6",
+              "from": "read@>=1.0.4 <1.1.0",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@>=0.0.4 <0.1.0"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.0.1",
+          "from": "q@>=1.0.1 <1.1.0"
+        },
+        "request": {
+          "version": "2.42.0",
+          "from": "request@>=2.42.0 <2.43.0",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@>=0.9.0 <0.10.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.6.0",
+              "from": "caseless@>=0.6.0 <0.7.0"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0"
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@>=1.2.0 <1.3.0"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@>=1.0.1 <1.1.0"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.0 <1.5.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0"
+            },
+            "tough-cookie": {
+              "version": "2.0.0",
+              "from": "tough-cookie@>=0.12.0"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0"
+                },
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.4.0",
+              "from": "oauth-sign@>=0.4.0 <0.5.0"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.0",
+          "from": "request-progress@0.3.0",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.0",
+          "from": "retry@0.6.0"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.0 <2.3.0"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@>=2.3.0 <2.4.0"
+        },
+        "shell-quote": {
+          "version": "1.4.3",
+          "from": "shell-quote@>=1.4.1 <1.5.0",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "array-filter@>=0.0.0 <0.1.0"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "array-reduce@>=0.0.0 <0.1.0"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "array-map@>=0.0.0 <0.1.0"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.1",
+          "from": "stringify-object@>=1.0.0 <1.1.0"
+        },
+        "tar-fs": {
+          "version": "0.5.2",
+          "from": "tar-fs@0.5.2",
+          "dependencies": {
+            "pump": {
+              "version": "0.3.5",
+              "from": "pump@>=0.3.5 <0.4.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.2.0",
+                  "from": "once@>=1.2.0 <1.3.0"
+                },
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "end-of-stream@>=1.0.0 <1.1.0",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "0.4.7",
+              "from": "tar-stream@>=0.4.6 <0.5.0",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.23",
+          "from": "tmp@0.0.23"
+        },
+        "update-notifier": {
+          "version": "0.2.0",
+          "from": "update-notifier@0.2.0",
+          "dependencies": {
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.3.1",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.2 <1.1.0",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.9.3",
+                          "from": "lodash@>=3.2.0 <4.0.0"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.2.0",
+                      "from": "esprima@>=2.2.0 <2.3.0"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "latest-version": {
+              "version": "0.2.0",
+              "from": "latest-version@>=0.2.0 <0.3.0",
+              "dependencies": {
+                "package-json": {
+                  "version": "0.2.0",
+                  "from": "package-json@>=0.2.0 <0.3.0",
+                  "dependencies": {
+                    "got": {
+                      "version": "0.3.0",
+                      "from": "got@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "object-assign": {
+                          "version": "0.3.1",
+                          "from": "object-assign@>=0.3.0 <0.4.0"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "0.1.1",
+                      "from": "registry-url@>=0.1.0 <0.2.0",
+                      "dependencies": {
+                        "npmconf": {
+                          "version": "2.1.2",
+                          "from": "npmconf@>=2.0.1 <3.0.0",
+                          "dependencies": {
+                            "config-chain": {
+                              "version": "1.1.9",
+                              "from": "config-chain@>=1.1.8 <1.2.0",
+                              "dependencies": {
+                                "proto-list": {
+                                  "version": "1.2.4",
+                                  "from": "proto-list@>=1.2.1 <1.3.0"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <2.1.0"
+                            },
+                            "ini": {
+                              "version": "1.3.4",
+                              "from": "ini@>=1.2.0 <2.0.0"
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "uid-number": {
+                              "version": "0.0.5",
+                              "from": "uid-number@0.0.5"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "0.1.0",
+              "from": "semver-diff@>=0.1.0 <0.2.0"
+            },
+            "string-length": {
+              "version": "0.1.2",
+              "from": "string-length@>=0.1.2 <0.2.0",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "0.2.2",
+                  "from": "strip-ansi@>=0.2.1 <0.3.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.1.0",
+                      "from": "ansi-regex@>=0.1.0 <0.2.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0"
+        }
+      }
+    },
+    "bower-npm-install": {
+      "version": "0.5.9",
+      "from": "bower-npm-install@>=0.5.4 <0.6.0",
+      "dependencies": {
+        "q": {
+          "version": "0.9.7",
+          "from": "q@>=0.9.6 <0.10.0"
+        },
+        "coa": {
+          "version": "0.4.1",
+          "from": "coa@>=0.4.0 <0.5.0"
+        },
+        "q-io": {
+          "version": "1.9.4",
+          "from": "q-io@>=1.9.1 <1.10.0",
+          "dependencies": {
+            "qs": {
+              "version": "0.1.0",
+              "from": "qs@>=0.1.0 <0.2.0"
+            },
+            "url2": {
+              "version": "0.0.0",
+              "from": "url2@>=0.0.0 <0.1.0"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@>=1.2.11 <1.3.0"
+            },
+            "mimeparse": {
+              "version": "0.1.4",
+              "from": "mimeparse@>=0.1.4 <0.2.0"
+            },
+            "collections": {
+              "version": "0.1.24",
+              "from": "collections@>=0.1.24 <0.2.0",
+              "dependencies": {
+                "weak-map": {
+                  "version": "1.0.0",
+                  "from": "weak-map@1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0"
+        },
+        "cli-color": {
+          "version": "0.2.3",
+          "from": "cli-color@>=0.2.3 <0.3.0",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.9.2",
+              "from": "es5-ext@>=0.9.2 <0.10.0"
+            },
+            "memoizee": {
+              "version": "0.2.6",
+              "from": "memoizee@>=0.2.5 <0.3.0",
+              "dependencies": {
+                "event-emitter": {
+                  "version": "0.2.2",
+                  "from": "event-emitter@>=0.2.2 <0.3.0"
+                },
+                "next-tick": {
+                  "version": "0.1.0",
+                  "from": "next-tick@>=0.1.0 <0.2.0"
+                }
+              }
+            }
+          }
+        },
+        "update-notifier": {
+          "version": "0.1.10",
+          "from": "update-notifier@>=0.1.7 <0.2.0",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@>=0.4.0 <0.5.0",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@>=0.1.0 <0.2.0"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@>=1.0.0 <1.1.0"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@>=0.1.0 <0.2.0"
+                }
+              }
+            },
+            "configstore": {
+              "version": "0.3.2",
+              "from": "configstore@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.1 <4.0.0"
+                },
+                "js-yaml": {
+                  "version": "3.3.1",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.2 <1.1.0",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.9.3",
+                          "from": "lodash@>=3.2.0 <4.0.0"
+                        },
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.2.0",
+                      "from": "esprima@>=2.2.0 <2.3.0"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0"
+                },
+                "osenv": {
+                  "version": "0.1.2",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.0.0 <2.0.0"
+                },
+                "uuid": {
+                  "version": "2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0"
+                },
+                "xdg-basedir": {
+                  "version": "1.0.1",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "request": {
+              "version": "2.58.0",
+              "from": "request@>=2.36.0 <3.0.0",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.10.0",
+                  "from": "caseless@>=0.10.0 <0.11.0"
+                },
+                "extend": {
+                  "version": "2.0.1",
+                  "from": "extend@>=2.0.1 <2.1.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.0 <0.7.0"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.2.1",
+                      "from": "async@>=1.2.1 <2.0.0"
+                    },
+                    "mime-types": {
+                      "version": "2.1.1",
+                      "from": "mime-types@>=2.1.1 <3.0.0",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.13.0",
+                          "from": "mime-db@>=1.13.0 <1.14.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "2.0.14",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.2 <2.0.0"
+                },
+                "qs": {
+                  "version": "3.1.0",
+                  "from": "qs@>=3.1.0 <3.2.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0"
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.14.0",
+                      "from": "hoek@>=2.0.0 <3.0.0"
+                    },
+                    "boom": {
+                      "version": "2.8.0",
+                      "from": "boom@>=2.0.0 <3.0.0"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@>=1.0.1 <1.1.0",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.1 <0.2.0"
+                },
+                "har-validator": {
+                  "version": "1.7.1",
+                  "from": "har-validator@>=1.6.1 <2.0.0",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.30",
+                      "from": "bluebird@>=2.9.26 <3.0.0"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@>=2.0.1 <3.0.0"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@>=1.0.3 <2.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.0.0 <2.0.0"
+                            },
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@>=2.0.1 <3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@>=1.3.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.0",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "semver@>=2.3.0 <3.0.0"
+            }
+          }
+        },
+        "byline": {
+          "version": "3.1.2",
+          "from": "git://github.com/SevInf/node-byline.git#2c546e682d503667ead0001090ecb9f27f62d928",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.4.1",
+          "from": "inquirer@>=0.4.0 <0.5.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.8 <0.3.0"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.4 <2.4.0"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enb": {
+      "version": "0.14.0",
+      "from": "enb@0.14.0",
+      "dependencies": {
+        "borschik": {
+          "version": "1.0.0",
+          "from": "borschik@1.0.0",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "coa": {
+              "version": "0.4.0",
+              "from": "coa@0.4.0",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.6 <0.10.0"
+                }
+              }
+            },
+            "inherit": {
+              "version": "2.2.1",
+              "from": "inherit@2.2.1"
+            },
+            "vow": {
+              "version": "0.3.12",
+              "from": "vow@0.3.12"
+            },
+            "csso": {
+              "version": "1.3.11",
+              "from": "csso@1.3.11"
+            },
+            "uglify-js": {
+              "version": "2.4.13",
+              "from": "uglify-js@2.4.13",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.33 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "1.1.1",
+          "from": "commander@1.1.1",
+          "dependencies": {
+            "keypress": {
+              "version": "0.1.0",
+              "from": "keypress@>=0.1.0 <0.2.0"
+            }
+          }
+        },
+        "connect": {
+          "version": "3.1.1",
+          "from": "connect@3.1.1",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.4",
+              "from": "debug@1.0.4",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.1.0",
+              "from": "finalhandler@0.1.0",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            }
+          }
+        },
+        "dom-js": {
+          "version": "0.0.9",
+          "from": "dom-js@0.0.9",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.1",
+              "from": "sax@>=0.1.5"
+            }
+          }
+        },
+        "inherit": {
+          "version": "2.1.0",
+          "from": "inherit@>=2.1.0 <2.2.0"
+        },
+        "js-yaml": {
+          "version": "2.1.0",
+          "from": "js-yaml@2.1.0",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0"
+            }
+          }
+        },
+        "mad": {
+          "version": "0.4.0",
+          "from": "mad@>=0.4.0"
+        },
+        "madify": {
+          "version": "0.0.1",
+          "from": "madify@>=0.0.1"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@1.2.11"
+        },
+        "puml-link": {
+          "version": "0.0.1",
+          "from": "puml-link@0.0.1"
+        },
+        "send": {
+          "version": "0.8.3",
+          "from": "send@0.8.3",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.4",
+              "from": "debug@1.0.4"
+            },
+            "depd": {
+              "version": "0.4.4",
+              "from": "depd@0.4.4"
+            },
+            "destroy": {
+              "version": "1.0.3",
+              "from": "destroy@1.0.3"
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1"
+            },
+            "fresh": {
+              "version": "0.2.2",
+              "from": "fresh@0.2.2"
+            },
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2"
+            },
+            "on-finished": {
+              "version": "2.1.0",
+              "from": "on-finished@2.1.0",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.0.5",
+                  "from": "ee-first@1.0.5"
+                }
+              }
+            },
+            "range-parser": {
+              "version": "1.0.2",
+              "from": "range-parser@>=1.0.0 <1.1.0"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.5.3",
+          "from": "serve-static@1.5.3",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            }
+          }
+        },
+        "sibling": {
+          "version": "0.1.3",
+          "from": "sibling@>=0.0.3",
+          "dependencies": {
+            "vow": {
+              "version": "0.4.10",
+              "from": "vow@>=0.4.1 <0.5.0"
+            }
+          }
+        },
+        "stylus": {
+          "version": "0.40.3",
+          "from": "stylus@>=0.40.0 <0.41.0",
+          "dependencies": {
+            "cssom": {
+              "version": "0.2.5",
+              "from": "cssom@>=0.2.0 <0.3.0"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.0 <0.4.0"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@*",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "sax": {
+              "version": "0.5.8",
+              "from": "sax@>=0.5.0 <0.6.0"
+            }
+          }
+        },
+        "vow": {
+          "version": "0.3.13",
+          "from": "vow@>=0.3.9 <0.4.0"
+        },
+        "vow-fs": {
+          "version": "0.2.3",
+          "from": "vow-fs@>=0.2.2 <0.3.0",
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.0",
+              "from": "node-uuid@1.4.0"
+            },
+            "vow-queue": {
+              "version": "0.0.2",
+              "from": "vow-queue@0.0.2"
+            }
+          }
+        }
+      }
+    },
+    "enb-bem-docs": {
+      "version": "0.7.3",
+      "from": "enb-bem-docs@0.7.3",
+      "dependencies": {
+        "bem-md-renderer": {
+          "version": "0.0.1",
+          "from": "bem-md-renderer@0.0.1"
+        },
+        "bem-jsd": {
+          "version": "1.5.3",
+          "from": "bem-jsd@1.5.3",
+          "dependencies": {
+            "jsd": {
+              "version": "1.1.2",
+              "from": "jsd@1.1.2",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                },
+                "inherit": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/inherit/-/inherit-2.1.0.tgz"
+                }
+              }
+            },
+            "jsd-plugins-bem": {
+              "version": "1.4.2",
+              "from": "jsd-plugins-bem@1.4.2",
+              "dependencies": {
+                "jspath": {
+                  "version": "0.2.11",
+                  "from": "jspath@0.2.11"
+                }
+              }
+            }
+          }
+        },
+        "enb-bem-pseudo-levels": {
+          "version": "0.2.6",
+          "from": "enb-bem-pseudo-levels@0.2.6",
+          "dependencies": {
+            "enb-bem-techs": {
+              "version": "1.0.0",
+              "from": "enb-bem-techs@1.0.0",
+              "dependencies": {
+                "bem-naming": {
+                  "version": "0.4.0",
+                  "from": "bem-naming@0.4.0"
+                },
+                "js-yaml": {
+                  "version": "3.2.3",
+                  "from": "js-yaml@3.2.3",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.16",
+                      "from": "argparse@>=0.1.11 <0.2.0",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.7.0",
+                          "from": "underscore@>=1.7.0 <1.8.0"
+                        },
+                        "underscore.string": {
+                          "version": "2.4.0",
+                          "from": "underscore.string@>=2.4.0 <2.5.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "enb-bem-techs": {
+          "version": "1.0.2",
+          "from": "enb-bem-techs@1.0.2",
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.2.5",
+              "from": "js-yaml@3.2.5",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.16",
+                  "from": "argparse@>=0.1.11 <0.2.0",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.7.0",
+                      "from": "underscore@>=1.7.0 <1.8.0"
+                    },
+                    "underscore.string": {
+                      "version": "2.4.0",
+                      "from": "underscore.string@>=2.4.0 <2.5.0"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@>=1.0.2 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "inherit": {
+          "version": "2.2.2",
+          "from": "inherit@2.2.2"
+        },
+        "jsdoc": {
+          "version": "3.3.0-alpha9",
+          "from": "jsdoc@3.3.0-alpha9",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@>=0.1.22 <0.2.0"
+            },
+            "catharsis": {
+              "version": "0.8.7",
+              "from": "catharsis@>=0.8.2 <0.9.0",
+              "dependencies": {
+                "underscore-contrib": {
+                  "version": "0.3.0",
+                  "from": "underscore-contrib@>=0.3.0 <0.4.0"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.1.0-dev-harmony",
+              "from": "https://github.com/ariya/esprima/tarball/49a2eccb243f29bd653b11e9419241a9d726af7c"
+            },
+            "js2xmlparser": {
+              "version": "0.1.9",
+              "from": "js2xmlparser@>=0.1.0 <0.2.0"
+            },
+            "requizzle": {
+              "version": "0.2.1",
+              "from": "requizzle@>=0.2.0 <0.3.0"
+            },
+            "strip-json-comments": {
+              "version": "0.1.3",
+              "from": "strip-json-comments@>=0.1.3 <0.2.0"
+            },
+            "taffydb": {
+              "version": "2.6.2",
+              "from": "https://github.com/hegemonic/taffydb/tarball/master"
+            },
+            "underscore": {
+              "version": "1.6.0",
+              "from": "underscore@>=1.6.0 <1.7.0"
+            },
+            "wrench": {
+              "version": "1.3.9",
+              "from": "wrench@>=1.3.9 <1.4.0"
+            }
+          }
+        },
+        "jsdoc-bem": {
+          "version": "0.2.1",
+          "from": "jsdoc-bem@0.2.1"
+        },
+        "jsdtmd": {
+          "version": "0.0.8",
+          "from": "jsdtmd@0.0.8",
+          "dependencies": {
+            "bem-xjst": {
+              "version": "0.6.1",
+              "from": "bem-xjst@>=0.6.0 <0.7.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@>=1.5.0 <1.6.0"
+                },
+                "esprima": {
+                  "version": "1.1.1",
+                  "from": "esprima@>=1.1.1 <1.2.0"
+                },
+                "ometajs": {
+                  "version": "3.2.4",
+                  "from": "ometajs@>=3.2.4 <3.3.0",
+                  "dependencies": {
+                    "q": {
+                      "version": "0.8.12",
+                      "from": "q@>=0.8.0 <0.9.0"
+                    },
+                    "uglify-js": {
+                      "version": "1.3.5",
+                      "from": "uglify-js@>=1.3.0 <1.4.0"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.2 <2.4.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "amdefine@>=0.0.4"
+                        }
+                      }
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "wordwrap@>=0.0.2 <0.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "xjst": {
+                  "version": "1.3.8",
+                  "from": "xjst@>=1.3.7 <1.4.0",
+                  "dependencies": {
+                    "coa": {
+                      "version": "0.4.1",
+                      "from": "coa@>=0.4.0 <0.5.0"
+                    },
+                    "uglify-js": {
+                      "version": "2.4.23",
+                      "from": "uglify-js@>=2.4.0 <2.5.0",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@>=0.2.6 <0.3.0"
+                        },
+                        "source-map": {
+                          "version": "0.1.34",
+                          "from": "source-map@0.1.34",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.1",
+                              "from": "amdefine@>=0.0.4"
+                            }
+                          }
+                        },
+                        "uglify-to-browserify": {
+                          "version": "1.0.2",
+                          "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+                        },
+                        "yargs": {
+                          "version": "3.5.4",
+                          "from": "yargs@>=3.5.4 <3.6.0",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.1.0",
+                              "from": "camelcase@>=1.0.2 <2.0.0"
+                            },
+                            "decamelize": {
+                              "version": "1.0.0",
+                              "from": "decamelize@>=1.0.0 <2.0.0"
+                            },
+                            "window-size": {
+                              "version": "0.1.0",
+                              "from": "window-size@0.1.0"
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "coa": {
+                  "version": "0.3.9",
+                  "from": "coa@>=0.3.9 <0.4.0",
+                  "dependencies": {
+                    "q": {
+                      "version": "0.8.12",
+                      "from": "q@>=0.8.10 <0.9.0"
+                    }
+                  }
+                },
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.3 <0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "marked": {
+          "version": "0.3.2",
+          "from": "marked@0.3.2"
+        },
+        "toc-md": {
+          "version": "0.0.1",
+          "from": "toc-md@0.0.1",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@2.4.1"
+            },
+            "coa": {
+              "version": "0.4.1",
+              "from": "coa@0.4.1",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.6 <0.10.0"
+                }
+              }
+            },
+            "vow-fs": {
+              "version": "0.3.3",
+              "from": "vow-fs@0.3.3",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "node-uuid@1.4.0"
+                },
+                "vow": {
+                  "version": "0.4.4",
+                  "from": "vow@0.4.4"
+                },
+                "vow-queue": {
+                  "version": "0.4.1",
+                  "from": "vow-queue@0.4.1"
+                },
+                "glob": {
+                  "version": "3.2.8",
+                  "from": "glob@3.2.8",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "colors": {
+              "version": "1.0.3",
+              "from": "colors@1.0.3"
+            }
+          }
+        },
+        "shmakowiki": {
+          "version": "0.4.0",
+          "from": "shmakowiki@0.4.0",
+          "dependencies": {
+            "ometajs": {
+              "version": "2.1.10",
+              "from": "ometajs@>=2.1.0 <2.2.0",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "1.1.1",
+                  "from": "uglify-js@>=1.1.0 <1.2.0"
+                }
+              }
+            },
+            "ometa-highlighter": {
+              "version": "0.2.3",
+              "from": "ometa-highlighter@>=0.2.3 <0.3.0"
+            },
+            "q": {
+              "version": "0.7.2",
+              "from": "q@>=0.7.0 <0.8.0",
+              "dependencies": {
+                "event-queue": {
+                  "version": "0.2.0",
+                  "from": "event-queue@>=0.0.1"
+                }
+              }
+            },
+            "coa": {
+              "version": "0.3.9",
+              "from": "coa@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "q": {
+                  "version": "0.8.12",
+                  "from": "q@>=0.8.10 <0.9.0"
+                }
+              }
+            },
+            "highlight.js": {
+              "version": "7.5.0",
+              "from": "highlight.js@>=7.0.0 <8.0.0"
+            }
+          }
+        },
+        "vow": {
+          "version": "0.4.7",
+          "from": "vow@0.4.7"
+        },
+        "vow-node": {
+          "version": "0.2.1",
+          "from": "vow-node@0.2.1"
+        }
+      }
+    },
+    "enb-bem-examples": {
+      "version": "0.5.9",
+      "from": "enb-bem-examples@0.5.9",
+      "dependencies": {
+        "bem-naming": {
+          "version": "0.5.0",
+          "from": "bem-naming@0.5.0"
+        },
+        "enb-bem-pseudo-levels": {
+          "version": "0.2.6",
+          "from": "enb-bem-pseudo-levels@0.2.6",
+          "dependencies": {
+            "enb-bem-techs": {
+              "version": "1.0.0",
+              "from": "enb-bem-techs@1.0.0",
+              "dependencies": {
+                "bem-naming": {
+                  "version": "0.4.0",
+                  "from": "bem-naming@0.4.0"
+                },
+                "inherit": {
+                  "version": "2.2.2",
+                  "from": "inherit@2.2.2"
+                },
+                "js-yaml": {
+                  "version": "3.2.3",
+                  "from": "js-yaml@3.2.3",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.16",
+                      "from": "argparse@>=0.1.11 <0.2.0",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.7.0",
+                          "from": "underscore@>=1.7.0 <1.8.0"
+                        },
+                        "underscore.string": {
+                          "version": "2.4.0",
+                          "from": "underscore.string@>=2.4.0 <2.5.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vow": {
+          "version": "0.4.7",
+          "from": "vow@0.4.7"
+        }
+      }
+    },
+    "enb-bem-specs": {
+      "version": "0.5.6",
+      "from": "enb-bem-specs@0.5.6",
+      "dependencies": {
+        "borschik-tech-istanbul": {
+          "version": "0.2.0",
+          "from": "borschik-tech-istanbul@0.2.0",
+          "dependencies": {
+            "istanbul": {
+              "version": "0.2.16",
+              "from": "istanbul@>=0.2.3 <0.3.0",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.0 <1.3.0"
+                },
+                "escodegen": {
+                  "version": "1.3.3",
+                  "from": "escodegen@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "1.0.0",
+                      "from": "esutils@>=1.0.0 <1.1.0"
+                    },
+                    "estraverse": {
+                      "version": "1.5.1",
+                      "from": "estraverse@>=1.5.0 <1.6.0"
+                    },
+                    "esprima": {
+                      "version": "1.1.1",
+                      "from": "esprima@>=1.1.1 <1.2.0"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.33 <0.2.0",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "amdefine@>=0.0.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                "handlebars": {
+                  "version": "1.3.0",
+                  "from": "handlebars@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.0 <0.4.0"
+                    },
+                    "uglify-js": {
+                      "version": "2.3.6",
+                      "from": "uglify-js@>=2.3.0 <2.4.0",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@>=0.2.6 <0.3.0"
+                        },
+                        "source-map": {
+                          "version": "0.1.43",
+                          "from": "source-map@>=0.1.7 <0.2.0",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.1",
+                              "from": "amdefine@>=0.0.4"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.0 <4.0.0"
+                },
+                "fileset": {
+                  "version": "0.1.8",
+                  "from": "fileset@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.4.0",
+                      "from": "minimatch@>=0.0.0 <1.0.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    },
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.4",
+                              "from": "lru-cache@>=2.0.0 <3.0.0"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.0.9",
+                  "from": "which@>=1.0.0 <1.1.0"
+                },
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0"
+                },
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <1.1.0"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.0 <0.1.0"
+                },
+                "resolve": {
+                  "version": "0.7.4",
+                  "from": "resolve@>=0.7.0 <0.8.0"
+                },
+                "js-yaml": {
+                  "version": "3.3.1",
+                  "from": "js-yaml@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.2",
+                      "from": "argparse@>=1.0.2 <1.1.0",
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.2.0",
+                      "from": "esprima@>=2.2.0 <2.3.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "enb-bem-pseudo-levels": {
+          "version": "0.2.6",
+          "from": "enb-bem-pseudo-levels@0.2.6",
+          "dependencies": {
+            "vow": {
+              "version": "0.4.7",
+              "from": "vow@0.4.7"
+            },
+            "enb-bem-techs": {
+              "version": "1.0.0",
+              "from": "enb-bem-techs@1.0.0",
+              "dependencies": {
+                "bem-naming": {
+                  "version": "0.4.0",
+                  "from": "bem-naming@0.4.0"
+                },
+                "js-yaml": {
+                  "version": "3.2.3",
+                  "from": "js-yaml@3.2.3",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.16",
+                      "from": "argparse@>=0.1.11 <0.2.0",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.7.0",
+                          "from": "underscore@>=1.7.0 <1.8.0"
+                        },
+                        "underscore.string": {
+                          "version": "2.4.0",
+                          "from": "underscore.string@>=2.4.0 <2.5.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "enb-borschik": {
+          "version": "1.5.0",
+          "from": "enb-borschik@1.5.0",
+          "dependencies": {
+            "sibling": {
+              "version": "0.1.3",
+              "from": "sibling@>=0.1.3 <0.2.0",
+              "dependencies": {
+                "inherit": {
+                  "version": "2.1.0",
+                  "from": "inherit@>=2.1.0 <2.2.0"
+                }
+              }
+            }
+          }
+        },
+        "enb-stylus": {
+          "version": "1.2.3",
+          "from": "enb-stylus@1.2.3",
+          "dependencies": {
+            "vow": {
+              "version": "0.4.8",
+              "from": "vow@0.4.8"
+            },
+            "stylus": {
+              "version": "0.50.0",
+              "from": "stylus@0.50.0",
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.7.0",
+                  "from": "css-parse@>=1.7.0 <1.8.0"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.0 <0.4.0"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@*",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1"
+                    }
+                  }
+                },
+                "sax": {
+                  "version": "0.5.8",
+                  "from": "sax@>=0.5.0 <0.6.0"
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.0 <3.3.0",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "autoprefixer": {
+              "version": "3.1.0",
+              "from": "autoprefixer@>=3.1.0 <3.2.0",
+              "dependencies": {
+                "autoprefixer-core": {
+                  "version": "3.1.2",
+                  "from": "autoprefixer-core@>=3.1.0 <3.2.0",
+                  "dependencies": {
+                    "caniuse-db": {
+                      "version": "1.0.30000212",
+                      "from": "caniuse-db@>=1.0.30000006 <2.0.0"
+                    }
+                  }
+                },
+                "fs-extra": {
+                  "version": "0.11.1",
+                  "from": "fs-extra@>=0.11.1 <0.12.0",
+                  "dependencies": {
+                    "ncp": {
+                      "version": "0.6.0",
+                      "from": "ncp@>=0.6.0 <0.7.0"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8"
+                        }
+                      }
+                    },
+                    "jsonfile": {
+                      "version": "2.0.1",
+                      "from": "jsonfile@>=2.0.0 <3.0.0"
+                    },
+                    "rimraf": {
+                      "version": "2.4.0",
+                      "from": "rimraf@>=2.2.8 <3.0.0",
+                      "dependencies": {
+                        "glob": {
+                          "version": "4.5.3",
+                          "from": "glob@>=4.4.2 <5.0.0",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0"
+                            },
+                            "minimatch": {
+                              "version": "2.0.8",
+                              "from": "minimatch@>=2.0.1 <3.0.0",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "balanced-match@>=0.2.0 <0.3.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "postcss": {
+                  "version": "2.2.6",
+                  "from": "postcss@>=2.2.4 <2.3.0",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "amdefine@>=0.0.4"
+                        }
+                      }
+                    },
+                    "js-base64": {
+                      "version": "2.1.8",
+                      "from": "js-base64@>=2.1.5 <2.2.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inherit": {
+          "version": "2.2.2",
+          "from": "inherit@>=2.2.1 <3.0.0"
+        },
+        "istanbul": {
+          "version": "0.3.10",
+          "from": "istanbul@0.3.10",
+          "dependencies": {
+            "esprima": {
+              "version": "2.1.0",
+              "from": "esprima@>=2.1.0 <2.2.0"
+            },
+            "escodegen": {
+              "version": "1.6.1",
+              "from": "escodegen@>=1.6.0 <1.7.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <1.10.0"
+                },
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0"
+                },
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.6",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "3.0.0",
+              "from": "handlebars@3.0.0",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0"
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.0 <4.0.0"
+            },
+            "fileset": {
+              "version": "0.1.8",
+              "from": "fileset@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.4.0",
+                  "from": "minimatch@>=0.0.0 <1.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0"
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0"
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <1.4.0"
+            },
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <1.1.0"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.0 <0.1.0"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.0 <1.2.0"
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.5.0",
+          "from": "lodash@3.5.0"
+        },
+        "mocha-phantomjs": {
+          "version": "3.5.3",
+          "from": "mocha-phantomjs@3.5.3",
+          "dependencies": {
+            "mocha": {
+              "version": "1.20.1",
+              "from": "mocha@>=1.20.1 <1.21.0",
+              "dependencies": {
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@>=1.7.0 <1.8.0"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "commander@0.6.1"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.7",
+                  "from": "diff@1.0.7"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@*",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@0.3.5"
+                },
+                "glob": {
+                  "version": "3.2.3",
+                  "from": "glob@3.2.3",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "from": "graceful-fs@>=2.0.0 <2.1.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.0.0",
+              "from": "commander@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "phantomjs": {
+          "version": "1.9.16",
+          "from": "phantomjs@1.9.16",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4"
+            },
+            "fs-extra": {
+              "version": "0.16.5",
+              "from": "fs-extra@>=0.16.0 <0.17.0",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0"
+                },
+                "jsonfile": {
+                  "version": "2.0.1",
+                  "from": "jsonfile@>=2.0.0 <3.0.0"
+                },
+                "rimraf": {
+                  "version": "2.4.0",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0"
+                        },
+                        "minimatch": {
+                          "version": "2.0.8",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "kew": {
+              "version": "0.4.0",
+              "from": "kew@0.4.0"
+            },
+            "npmconf": {
+              "version": "2.1.1",
+              "from": "npmconf@2.1.1",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.2.0 <2.0.0"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.2",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5"
+                }
+              }
+            },
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@1.1.8"
+            },
+            "request": {
+              "version": "2.42.0",
+              "from": "request@2.42.0",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0"
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0"
+                    },
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@0.3.1",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0"
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.5 <1.1.0"
+            }
+          }
+        },
+        "enb-bembundle": {
+          "version": "1.1.0",
+          "from": "enb-bembundle@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "vow": {
+              "version": "0.4.3",
+              "from": "vow@0.4.3"
+            }
+          }
+        },
+        "borschik": {
+          "version": "1.3.2",
+          "from": "borschik@>=1.3.2 <2.0.0",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@0.2.14",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "coa": {
+              "version": "0.4.0",
+              "from": "coa@0.4.0",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.6 <0.10.0"
+                }
+              }
+            },
+            "inherit": {
+              "version": "2.2.1",
+              "from": "inherit@2.2.1"
+            },
+            "vow": {
+              "version": "0.3.13",
+              "from": "vow@0.3.13"
+            },
+            "vow-fs": {
+              "version": "0.3.2",
+              "from": "vow-fs@0.3.2",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "node-uuid@1.4.0"
+                },
+                "vow": {
+                  "version": "0.4.4",
+                  "from": "vow@0.4.4"
+                },
+                "vow-queue": {
+                  "version": "0.3.1",
+                  "from": "vow-queue@0.3.1"
+                },
+                "glob": {
+                  "version": "3.2.8",
+                  "from": "glob@3.2.8",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "csso": {
+              "version": "1.3.11",
+              "from": "csso@1.3.11"
+            },
+            "uglify-js": {
+              "version": "2.4.15",
+              "from": "uglify-js@2.4.15",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enb-bem-techs": {
+      "version": "1.0.4",
+      "from": "enb-bem-techs@>=1.0.3 <2.0.0",
+      "dependencies": {
+        "inherit": {
+          "version": "2.2.2",
+          "from": "inherit@2.2.2"
+        },
+        "js-yaml": {
+          "version": "3.2.7",
+          "from": "js-yaml@3.2.7",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "from": "argparse@>=1.0.0 <1.1.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.9.3",
+                  "from": "lodash@>=3.2.0 <4.0.0"
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.0.0",
+              "from": "esprima@>=2.0.0 <2.1.0"
+            }
+          }
+        },
+        "vow": {
+          "version": "0.4.8",
+          "from": "vow@0.4.8"
+        }
+      }
+    },
+    "enb-bem-tmpl-specs": {
+      "version": "0.11.2",
+      "from": "enb-bem-tmpl-specs@0.11.2",
+      "dependencies": {
+        "enb-bem-i18n": {
+          "version": "0.3.0",
+          "from": "enb-bem-i18n@0.3.0",
+          "dependencies": {
+            "dom-js": {
+              "version": "0.0.9",
+              "from": "dom-js@0.0.9",
+              "dependencies": {
+                "sax": {
+                  "version": "1.1.1",
+                  "from": "sax@>=0.1.5"
+                }
+              }
+            }
+          }
+        },
+        "enb-bem-pseudo-levels": {
+          "version": "0.2.6",
+          "from": "enb-bem-pseudo-levels@0.2.6",
+          "dependencies": {
+            "vow": {
+              "version": "0.4.7",
+              "from": "vow@0.4.7"
+            },
+            "enb-bem-techs": {
+              "version": "1.0.0",
+              "from": "enb-bem-techs@1.0.0",
+              "dependencies": {
+                "bem-naming": {
+                  "version": "0.4.0",
+                  "from": "bem-naming@0.4.0"
+                },
+                "js-yaml": {
+                  "version": "3.2.3",
+                  "from": "js-yaml@3.2.3",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "0.1.16",
+                      "from": "argparse@>=0.1.11 <0.2.0",
+                      "dependencies": {
+                        "underscore": {
+                          "version": "1.7.0",
+                          "from": "underscore@>=1.7.0 <1.8.0"
+                        },
+                        "underscore.string": {
+                          "version": "2.4.0",
+                          "from": "underscore.string@>=2.4.0 <2.5.0"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.2 <1.1.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "enb-source-map": {
+          "version": "1.5.0",
+          "from": "enb-source-map@1.5.0",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.33 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "btoa": {
+              "version": "1.1.2",
+              "from": "btoa@>=1.1.2 <2.0.0"
+            },
+            "atob": {
+              "version": "1.1.2",
+              "from": "atob@>=1.1.2 <2.0.0"
+            }
+          }
+        },
+        "html-differ": {
+          "version": "1.3.1",
+          "from": "html-differ@1.3.1",
+          "dependencies": {
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.0 <2.0.0"
+                }
+              }
+            },
+            "coa": {
+              "version": "0.4.0",
+              "from": "coa@0.4.0",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.6 <0.10.0"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.0.8",
+              "from": "diff@1.0.8"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@2.4.1"
+            },
+            "parse5": {
+              "version": "1.1.3",
+              "from": "parse5@1.1.3"
+            },
+            "vow": {
+              "version": "0.4.3",
+              "from": "vow@0.4.3"
+            },
+            "vow-fs": {
+              "version": "0.3.1",
+              "from": "vow-fs@0.3.1",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.0",
+                  "from": "node-uuid@1.4.0"
+                },
+                "vow-queue": {
+                  "version": "0.1.0",
+                  "from": "vow-queue@0.1.0"
+                },
+                "glob": {
+                  "version": "3.2.8",
+                  "from": "glob@3.2.8",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inherit": {
+          "version": "2.2.2",
+          "from": "inherit@2.2.2"
+        },
+        "istanbul": {
+          "version": "0.3.14",
+          "from": "istanbul@0.3.14",
+          "dependencies": {
+            "esprima": {
+              "version": "2.1.0",
+              "from": "esprima@>=2.1.0 <2.2.0"
+            },
+            "escodegen": {
+              "version": "1.6.1",
+              "from": "escodegen@>=1.6.0 <1.7.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0"
+                },
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0"
+                },
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.6",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "3.0.0",
+              "from": "handlebars@3.0.0",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0"
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.0 <4.0.0"
+            },
+            "fileset": {
+              "version": "0.1.8",
+              "from": "fileset@>=0.1.0 <0.2.0",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.4.0",
+                  "from": "minimatch@>=0.0.0 <1.0.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0"
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0"
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <1.4.0"
+            },
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <1.1.0"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.0 <0.1.0"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.0 <1.2.0"
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "jade": {
+          "version": "1.10.0",
+          "from": "jade@1.10.0",
+          "dependencies": {
+            "character-parser": {
+              "version": "1.2.1",
+              "from": "character-parser@1.2.1"
+            },
+            "clean-css": {
+              "version": "3.3.3",
+              "from": "clean-css@>=3.1.9 <4.0.0",
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "commander@>=2.8.0 <2.9.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.2",
+                  "from": "source-map@>=0.4.0 <0.5.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.6.0",
+              "from": "commander@>=2.6.0 <2.7.0"
+            },
+            "constantinople": {
+              "version": "3.0.1",
+              "from": "constantinople@>=3.0.1 <3.1.0",
+              "dependencies": {
+                "acorn-globals": {
+                  "version": "1.0.4",
+                  "from": "acorn-globals@>=1.0.0 <2.0.0",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.1 <2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "jstransformer": {
+              "version": "0.0.2",
+              "from": "jstransformer@0.0.2",
+              "dependencies": {
+                "is-promise": {
+                  "version": "2.0.0",
+                  "from": "is-promise@>=2.0.0 <3.0.0"
+                },
+                "promise": {
+                  "version": "6.1.0",
+                  "from": "promise@>=6.0.1 <7.0.0",
+                  "dependencies": {
+                    "asap": {
+                      "version": "1.0.0",
+                      "from": "asap@>=1.0.0 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "transformers": {
+              "version": "2.1.0",
+              "from": "transformers@2.1.0",
+              "dependencies": {
+                "promise": {
+                  "version": "2.0.0",
+                  "from": "promise@>=2.0.0 <2.1.0",
+                  "dependencies": {
+                    "is-promise": {
+                      "version": "1.0.1",
+                      "from": "is-promise@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "css": {
+                  "version": "1.0.8",
+                  "from": "css@>=1.0.8 <1.1.0",
+                  "dependencies": {
+                    "css-parse": {
+                      "version": "1.0.4",
+                      "from": "css-parse@1.0.4"
+                    },
+                    "css-stringify": {
+                      "version": "1.0.5",
+                      "from": "css-stringify@1.0.5"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.2.5",
+                  "from": "uglify-js@>=2.2.5 <2.3.0",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.1",
+                          "from": "amdefine@>=0.0.4"
+                        }
+                      }
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "wordwrap@>=0.0.2 <0.1.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.4.19 <3.0.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "void-elements": {
+              "version": "2.0.1",
+              "from": "void-elements@>=2.0.1 <2.1.0"
+            },
+            "with": {
+              "version": "4.0.3",
+              "from": "with@>=4.0.0 <4.1.0",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.2.2",
+                  "from": "acorn@>=1.0.1 <2.0.0"
+                },
+                "acorn-globals": {
+                  "version": "1.0.4",
+                  "from": "acorn-globals@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "js-beautify": {
+          "version": "1.5.6",
+          "from": "js-beautify@1.5.6",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.9",
+              "from": "config-chain@>=1.1.5 <1.2.0",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "proto-list@>=1.2.1 <1.3.0"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "from": "lodash@3.9.3"
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@2.0.8",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "mocha": {
+          "version": "2.2.5",
+          "from": "mocha@2.2.5",
+          "dependencies": {
+            "commander": {
+              "version": "2.3.0",
+              "from": "commander@2.3.0"
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@2.0.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.4.0",
+              "from": "diff@1.4.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "from": "escape-string-regexp@1.0.2"
+            },
+            "glob": {
+              "version": "3.2.3",
+              "from": "glob@3.2.3",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                }
+              }
+            },
+            "growl": {
+              "version": "1.8.1",
+              "from": "growl@1.8.1"
+            },
+            "jade": {
+              "version": "0.26.3",
+              "from": "jade@0.26.3",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "mkdirp@0.3.0"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@0.5.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "from": "supports-color@>=1.2.0 <1.3.0"
+            }
+          }
+        },
+        "vow-fs": {
+          "version": "0.3.4",
+          "from": "vow-fs@0.3.4",
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.2 <2.0.0"
+            },
+            "vow-queue": {
+              "version": "0.4.2",
+              "from": "vow-queue@>=0.4.1 <0.5.0"
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.3.1 <5.0.0",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "enb-bembundle": {
+      "version": "1.1.0",
+      "from": "enb-bembundle@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "vow": {
+          "version": "0.4.3",
+          "from": "vow@0.4.3"
+        }
+      }
+    },
+    "enb-bemxjst": {
+      "version": "1.3.4",
+      "from": "enb-bemxjst@1.3.4",
+      "dependencies": {
+        "sibling": {
+          "version": "0.1.3",
+          "from": "sibling@0.1.3",
+          "dependencies": {
+            "inherit": {
+              "version": "2.1.0",
+              "from": "inherit@>=2.1.0 <2.2.0"
+            }
+          }
+        },
+        "vow": {
+          "version": "0.4.7",
+          "from": "vow@0.4.7"
+        }
+      }
+    },
+    "enb-bh": {
+      "version": "0.5.0",
+      "from": "enb-bh@0.5.0",
+      "dependencies": {
+        "enb-source-map": {
+          "version": "1.5.0",
+          "from": "enb-source-map@1.5.0",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.33 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "btoa": {
+              "version": "1.1.2",
+              "from": "btoa@>=1.1.2 <2.0.0"
+            },
+            "atob": {
+              "version": "1.1.2",
+              "from": "atob@>=1.1.2 <2.0.0"
+            }
+          }
+        }
+      }
+    },
+    "enb-borschik": {
+      "version": "1.5.1",
+      "from": "enb-borschik@>=1.5.1 <2.0.0",
+      "dependencies": {
+        "inherit": {
+          "version": "2.2.2",
+          "from": "inherit@>=2.2.1 <3.0.0"
+        },
+        "sibling": {
+          "version": "0.1.3",
+          "from": "sibling@>=0.1.3 <0.2.0",
+          "dependencies": {
+            "inherit": {
+              "version": "2.1.0",
+              "from": "inherit@>=2.1.0 <2.2.0"
+            }
+          }
+        }
+      }
+    },
+    "enb-magic-factory": {
+      "version": "0.4.4",
+      "from": "enb-magic-factory@>=0.4.0 <1.0.0",
+      "dependencies": {
+        "vow": {
+          "version": "0.4.8",
+          "from": "vow@0.4.8"
+        },
+        "minimist": {
+          "version": "1.1.0",
+          "from": "minimist@1.1.0"
+        }
+      }
+    },
+    "enb-magic-platform": {
+      "version": "0.5.0",
+      "from": "enb-magic-platform@0.5.0",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@1.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0"
+            }
+          }
+        },
+        "coa": {
+          "version": "1.0.1",
+          "from": "coa@1.0.1",
+          "dependencies": {
+            "q": {
+              "version": "1.4.1",
+              "from": "q@>=1.1.2 <2.0.0"
+            }
+          }
+        },
+        "connect": {
+          "version": "3.3.5",
+          "from": "connect@3.3.5",
+          "dependencies": {
+            "debug": {
+              "version": "2.1.3",
+              "from": "debug@>=2.1.3 <2.2.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.3.4",
+              "from": "finalhandler@0.3.4",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1"
+                },
+                "on-finished": {
+                  "version": "2.2.1",
+                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            }
+          }
+        },
+        "serve-favicon": {
+          "version": "2.2.0",
+          "from": "serve-favicon@2.2.0",
+          "dependencies": {
+            "etag": {
+              "version": "1.5.1",
+              "from": "etag@>=1.5.1 <1.6.0",
+              "dependencies": {
+                "crc": {
+                  "version": "3.2.1",
+                  "from": "crc@3.2.1"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4"
+            },
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.6.4",
+          "from": "serve-index@1.6.4",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.9",
+              "from": "accepts@>=1.2.7 <1.3.0",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.1",
+                  "from": "mime-types@>=2.1.1 <2.2.0",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.13.0",
+                      "from": "mime-db@>=1.13.0 <1.14.0"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.5.3",
+                  "from": "negotiator@0.5.3"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.2",
+              "from": "batch@0.5.2"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "from": "mime-types@>=2.0.11 <2.1.0",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "from": "mime-db@>=1.12.0 <1.13.0"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.9.2",
+          "from": "serve-static@1.9.2",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0"
+            },
+            "send": {
+              "version": "0.12.2",
+              "from": "send@0.12.2",
+              "dependencies": {
+                "debug": {
+                  "version": "2.1.3",
+                  "from": "debug@>=2.1.3 <2.2.0"
+                },
+                "depd": {
+                  "version": "1.0.1",
+                  "from": "depd@>=1.0.0 <1.1.0"
+                },
+                "destroy": {
+                  "version": "1.0.3",
+                  "from": "destroy@1.0.3"
+                },
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@>=1.5.1 <1.6.0",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1"
+                    }
+                  }
+                },
+                "fresh": {
+                  "version": "0.2.4",
+                  "from": "fresh@0.2.4"
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4"
+                },
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0"
+                },
+                "on-finished": {
+                  "version": "2.2.1",
+                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "1.0.2",
+                  "from": "range-parser@>=1.0.2 <1.1.0"
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            }
+          }
+        }
+      }
+    },
+    "enb-modules": {
+      "version": "0.2.0",
+      "from": "enb-modules@0.2.0",
+      "dependencies": {
+        "inherit": {
+          "version": "2.1.0",
+          "from": "inherit@>=2.1.0 <2.2.0"
+        }
+      }
+    },
+    "git-hooks": {
+      "version": "0.0.10",
+      "from": "git-hooks@>=0.0.6 <0.1.0"
+    },
+    "glob": {
+      "version": "3.2.8",
+      "from": "glob@3.2.8",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0"
+            }
+          }
+        }
+      }
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@2.0.1"
+    },
+    "istanbul": {
+      "version": "0.3.15",
+      "from": "istanbul@>=0.3.2 <0.4.0",
+      "dependencies": {
+        "esprima": {
+          "version": "2.1.0",
+          "from": "esprima@>=2.1.0 <2.2.0"
+        },
+        "escodegen": {
+          "version": "1.6.1",
+          "from": "escodegen@>=1.6.0 <1.7.0",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "estraverse@>=1.9.1 <2.0.0"
+            },
+            "esutils": {
+              "version": "1.1.6",
+              "from": "esutils@>=1.1.6 <2.0.0"
+            },
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.2 <2.0.0"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.2 <0.2.0"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.6",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.40 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            }
+          }
+        },
+        "handlebars": {
+          "version": "3.0.0",
+          "from": "handlebars@3.0.0",
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.40 <0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.5 <0.4.0"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "nopt@>=3.0.0 <4.0.0"
+        },
+        "fileset": {
+          "version": "0.1.6",
+          "from": "fileset@0.1.6",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.4.0",
+              "from": "minimatch@>=0.0.0 <1.0.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "glob": {
+              "version": "5.0.10",
+              "from": "glob@>=5.0.0 <6.0.0",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.0 <1.1.0"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0"
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "from": "supports-color@>=1.3.0 <1.4.0"
+        },
+        "abbrev": {
+          "version": "1.0.7",
+          "from": "abbrev@>=1.0.0 <1.1.0"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.0 <0.1.0"
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "from": "resolve@>=1.1.0 <1.2.0"
+        },
+        "js-yaml": {
+          "version": "3.3.1",
+          "from": "js-yaml@>=3.0.0 <4.0.0",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "from": "argparse@>=1.0.2 <1.1.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.9.3",
+                  "from": "lodash@>=3.2.0 <4.0.0"
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.2.0",
+              "from": "esprima@>=2.2.0 <2.3.0"
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.2",
+          "from": "once@>=1.0.0 <2.0.0",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@>=1.0.0 <2.0.0"
+            }
+          }
+        }
+      }
+    },
+    "jscs": {
+      "version": "1.11.3",
+      "from": "jscs@1.11.3",
+      "dependencies": {
+        "cli-table": {
+          "version": "0.3.1",
+          "from": "cli-table@>=0.3.1 <0.4.0"
+        },
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@>=1.0.3 <1.1.0"
+        },
+        "commander": {
+          "version": "2.6.0",
+          "from": "commander@>=2.6.0 <2.7.0"
+        },
+        "esprima": {
+          "version": "1.2.5",
+          "from": "esprima@>=1.2.4 <1.3.0"
+        },
+        "esprima-harmony-jscs": {
+          "version": "1.1.0-tolerate-import",
+          "from": "esprima-harmony-jscs@1.1.0-tolerate-import"
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <1.10.0"
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.2 <0.2.0"
+        },
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.5 <4.4.0",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "3.0.0",
+          "from": "lodash.assign@>=3.0.0 <3.1.0",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0"
+                },
+                "lodash.keys": {
+                  "version": "3.1.1",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@>=2.0.1 <2.1.0",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "prompt": {
+          "version": "0.2.14",
+          "from": "prompt@>=0.2.14 <0.3.0",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@>=0.0.0 <1.0.0"
+            },
+            "read": {
+              "version": "1.0.6",
+              "from": "read@>=1.0.0 <1.1.0",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@>=0.0.4 <0.1.0"
+                }
+              }
+            },
+            "revalidator": {
+              "version": "0.1.8",
+              "from": "revalidator@>=0.1.0 <0.2.0"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@>=0.2.0 <0.3.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@*"
+                },
+                "i": {
+                  "version": "0.3.3",
+                  "from": "i@>=0.3.0 <0.4.0"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.0.0 <1.0.0",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@>=0.4.0 <0.5.0"
+                },
+                "rimraf": {
+                  "version": "2.4.0",
+                  "from": "rimraf@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0"
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "winston": {
+              "version": "0.8.3",
+              "from": "winston@>=0.8.0 <0.9.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.0 <0.3.0"
+                },
+                "colors": {
+                  "version": "0.6.2",
+                  "from": "colors@>=0.6.0 <0.7.0"
+                },
+                "cycle": {
+                  "version": "1.0.3",
+                  "from": "cycle@>=1.0.0 <1.1.0"
+                },
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "eyes@>=0.1.0 <0.2.0"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.0 <0.2.0"
+                },
+                "stack-trace": {
+                  "version": "0.0.9",
+                  "from": "stack-trace@>=0.0.0 <0.1.0"
+                }
+              }
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@>=1.0.2 <1.1.0"
+        },
+        "supports-color": {
+          "version": "1.2.1",
+          "from": "supports-color@>=1.2.0 <1.3.0"
+        },
+        "vow-fs": {
+          "version": "0.3.4",
+          "from": "vow-fs@>=0.3.4 <0.4.0",
+          "dependencies": {
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@>=1.4.2 <2.0.0"
+            },
+            "vow-queue": {
+              "version": "0.4.2",
+              "from": "vow-queue@>=0.4.1 <0.5.0"
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "2.5.2",
+          "from": "xmlbuilder@>=2.5.0 <2.6.0",
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "from": "lodash@>=3.2.0 <3.3.0"
+            }
+          }
+        }
+      }
+    },
+    "jscs-jsdoc": {
+      "version": "0.4.5",
+      "from": "jscs-jsdoc@0.4.5",
+      "dependencies": {
+        "comment-parser": {
+          "version": "0.2.4",
+          "from": "comment-parser@0.2.4"
+        },
+        "jsdoctypeparser": {
+          "version": "1.2.0",
+          "from": "jsdoctypeparser@>=1.1.4 <2.0.0",
+          "dependencies": {
+            "lodash": {
+              "version": "3.9.3",
+              "from": "lodash@>=3.7.0 <4.0.0"
+            }
+          }
+        }
+      }
+    },
+    "jshint": {
+      "version": "2.8.0",
+      "from": "jshint@>=2.1.10 <3.0.0",
+      "dependencies": {
+        "cli": {
+          "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0"
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0"
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "dependencies": {
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.1.3",
+              "from": "domelementtype@1.1.3"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@>=2.0.0 <2.1.0",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0"
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0"
+        }
+      }
+    },
+    "jshint-groups": {
+      "version": "0.6.0",
+      "from": "jshint-groups@0.6.0",
+      "dependencies": {
+        "commander": {
+          "version": "1.1.1",
+          "from": "commander@>=1.1.0 <1.2.0",
+          "dependencies": {
+            "keypress": {
+              "version": "0.1.0",
+              "from": "keypress@>=0.1.0 <0.2.0"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@>=3.2.0 <3.3.0",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.0 <0.3.0",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0"
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@>=1.4.0 <1.5.0"
+        }
+      }
+    },
+    "mocha": {
+      "version": "1.9.0",
+      "from": "mocha@>=1.9.0 <1.10.0",
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "from": "commander@0.6.1"
+        },
+        "growl": {
+          "version": "1.7.0",
+          "from": "growl@>=1.7.0 <1.8.0"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "jade@0.26.3",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.2",
+          "from": "diff@1.0.2"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@*",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.3",
+          "from": "mkdirp@0.3.3"
+        },
+        "ms": {
+          "version": "0.3.0",
+          "from": "ms@0.3.0"
+        }
+      }
+    },
+    "reqf": {
+      "version": "1.0.0",
+      "from": "reqf@>=1.0.0 <2.0.0"
+    },
+    "vow": {
+      "version": "0.4.9",
+      "from": "vow@0.4.9"
+    },
+    "ym": {
+      "version": "0.1.0",
+      "from": "ym@0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
npm-shrinkwrap should prevent accident breaks after npm dependencies update (current `xjst` version, for example)

/jfi @tadatuta
