### PR TITLE
Updated ENB packages

### DIFF
--- a/.enb/make.js
+++ b/.enb/make.js
@@ -13,9 +13,9 @@ var LIB_NAME = 'bem-core',
     css = require('enb/techs/css'),
     js = require('enb/techs/js'),
     ym = require('enb-modules/techs/prepend-modules'),
-    bemhtml = require('enb-bemxjst/techs/bemhtml-old'),
-    bemtree = require('enb-bemxjst/techs/bemtree-old'),
-    html = require('enb-bemxjst/techs/html-from-bemjson'),
+    bemhtml = require('enb-bemxjst/techs/bemhtml'),
+    bemtree = require('enb-bemxjst/techs/bemtree'),
+    html = require('enb-bemxjst/techs/bemjson-to-html'),
     htmlFromData = require('./techs/html-from-bemtree'),
     bh = require('enb-bh/techs/bh-server'),
     bhServerInclude = require('enb-bh/techs/bh-server-include'),
@@ -302,11 +302,11 @@ module.exports = function(config) {
                         }
                     },
                     'bemhtml-dev' : {
-                        tech : 'enb-bemxjst/techs/bemhtml-old',
+                        tech : 'enb-bemxjst/techs/bemhtml',
                         options : { devMode : true }
                     },
                     'bemhtml-prod' : {
-                        tech : 'enb-bemxjst/techs/bemhtml-old',
+                        tech : 'enb-bemxjst/techs/bemhtml',
                         options : { devMode : false }
                     }
                 }

--- a/.enb/make.js
+++ b/.enb/make.js
@@ -291,13 +291,15 @@ module.exports = function(config) {
                 destPath : platform + '.specs',
                 levels : getLevels(platform),
                 sourceLevels : getSpecLevels(platform),
-                jsSuffixes : ['vanilla.js', 'browser.js', 'js']
+                jsSuffixes : ['vanilla.js', 'browser.js', 'js'],
+                depsTech : deps
             });
 
             sets.tmplSpecs.configure({
                 destPath : platform + '.tmpl-specs',
                 levels : getLevels(platform),
                 sourceLevels : getLevels(platform),
+                depsTech : deps,
                 engines : {
                     bh : {
                         tech : 'enb-bh/techs/bh-commonjs',

--- a/.enb/make.js
+++ b/.enb/make.js
@@ -17,10 +17,13 @@ var LIB_NAME = 'bem-core',
     bemtree = require('enb-bemxjst/techs/bemtree'),
     html = require('enb-bemxjst/techs/bemjson-to-html'),
     htmlFromData = require('./techs/html-from-bemtree'),
-    bh = require('enb-bh/techs/bh-server'),
-    bhServerInclude = require('enb-bh/techs/bh-server-include'),
-    bhYm = require('enb-bh/techs/bh-client-module'),
-    bhHtml = require('enb-bh/techs/html-from-bemjson'),
+    bhCommonJS = require('enb-bh/techs/bh-commonjs'),
+    bhBundle = require('enb-bh/techs/bh-bundle'),
+    bhHtml = require('enb-bh/techs/bemjson-to-html'),
+    bhOptions = {
+        jsAttrName : 'data-bem',
+        jsAttrScheme : 'json'
+    },
     copyFile = require('enb/techs/file-copy'),
     mergeFiles = require('enb/techs/file-merge'),
     borschik = require('enb-borschik/techs/borschik'),
@@ -69,8 +72,10 @@ module.exports = function(config) {
                         target : LIB_NAME + '.dev.js'
                     }],
                     [bemhtml, { target : LIB_NAME + '.dev.bemhtml.js', devMode : false }],
-                    [bhYm, { target : '.tmp.browser.bh.js', jsAttrName : 'data-bem', jsAttrScheme : 'json' }],
-                    [bhServerInclude, { target : LIB_NAME + '.dev.bh.js', jsAttrName : 'data-bem', jsAttrScheme : 'json' }],
+                    [bhBundle, {
+                        target : LIB_NAME + '.dev.bh.js',
+                        bhOptions : bhOptions
+                    }],
                     [mergeFiles, {
                         target : '.tmp.source+bemhtml.js',
                         sources : ['.tmp.source.js', LIB_NAME + '.dev.bemhtml.js']
@@ -81,7 +86,7 @@ module.exports = function(config) {
                     }],
                     [mergeFiles, {
                         target : '.tmp.source+bh.js',
-                        sources : ['.tmp.source.js', '.tmp.browser.bh.js']
+                        sources : ['.tmp.source.js', LIB_NAME + '.dev.bh.js']
                     }],
                     [ym, {
                         source : '.tmp.source+bh.js',
@@ -202,7 +207,7 @@ module.exports = function(config) {
             // Template techs
             nodeConfig.addTechs([
                 [bemhtml],
-                [bh, { jsAttrName : 'data-bem', jsAttrScheme : 'json' }]
+                [bhCommonJS, { devMode : false, bhOptions : bhOptions }]
             ]);
 
             nodeConfig.addTargets([
@@ -295,10 +300,10 @@ module.exports = function(config) {
                 sourceLevels : getLevels(platform),
                 engines : {
                     bh : {
-                        tech : 'enb-bh/techs/bh-server',
+                        tech : 'enb-bh/techs/bh-commonjs',
                         options : {
-                            jsAttrName : 'data-bem',
-                            jsAttrScheme : 'json'
+                            devMode : false,
+                            bhOptions : bhOptions
                         }
                     },
                     'bemhtml-dev' : {

--- a/.enb/techs/html-from-bemtree.js
+++ b/.enb/techs/html-from-bemtree.js
@@ -6,9 +6,9 @@
  *
  * **Опции**
  *
- * * *String* **bemhtmlTarget** — Исходный BEMHTML-файл. По умолчанию — `?.bemhtml.js`.
- * * *String* **bemtreeTarget** — Исходный BEMJSON-файл. По умолчанию — `?.bemtree.js`.
- * * *String* **destTarget** — Результирующий HTML-файл. По умолчанию — `?.html`.
+ * * *String* **bemhtmlFile** — Исходный BEMHTML-файл. По умолчанию — `?.bemhtml.js`.
+ * * *String* **bemtreeFile** — Исходный BEMJSON-файл. По умолчанию — `?.bemtree.js`.
+ * * *String* **target** — Результирующий HTML-файл. По умолчанию — `?.html`.
  *
  * **Пример**
  *
@@ -16,36 +16,27 @@
  * nodeConfig.addTech(require('enb/techs/html-from-bemjson'));
  * ```
  */
-var vm = require('vm'),
-    vow = require('vow'),
-    vfs = require('enb/lib/fs/async-fs'),
+var vow = require('vow'),
     asyncRequire = require('enb/lib/fs/async-require'),
     dropRequireCache = require('enb/lib/fs/drop-require-cache');
 
 module.exports = require('enb/lib/build-flow').create()
     .name('html-from-bemtree')
-    .target('destTarget', '?.html')
-    .useSourceFilename('bemtreeTarget', '?.bemtree.js')
-    .useSourceFilename('bemhtmlTarget', '?.bemhtml.js')
+    .target('target', '?.html')
+    .useSourceFilename('bemtreeFile', '?.bemtree.js')
+    .useSourceFilename('bemhtmlFile', '?.bemhtml.js')
     .builder(function(bemtreeFilename, bemhtmlFilename) {
+        dropRequireCache(require, bemtreeFilename);
         dropRequireCache(require, bemhtmlFilename);
 
         return vow.all([
-                vfs.read(bemtreeFilename, 'utf-8'),
+                asyncRequire(bemtreeFilename),
                 asyncRequire(bemhtmlFilename)
             ])
             .spread(function(bemtree, bemhtml) {
-                var ctx = vm.createContext({
-                    Vow : vow,
-                    console : console,
-                    setTimeout : setTimeout
-                });
+                var BEMTREE = bemtree.BEMTREE,
+                    BEMHTML = bemhtml.BEMHTML;
 
-                vm.runInContext(bemtree, ctx);
-
-                return [ctx.BEMTREE, bemhtml.BEMHTML];
-            })
-            .spread(function(BEMTREE, BEMHTML) {
                 return BEMTREE.apply({})
                     .then(function(bemjson) {
                         return BEMHTML.apply(bemjson);

--- a/common.blocks/i-bem/__dom/_init/i-bem__dom_init_auto.deps.js
+++ b/common.blocks/i-bem/__dom/_init/i-bem__dom_init_auto.deps.js
@@ -1,3 +1,3 @@
 ({
-    shouldDeps : { elem : 'dom', mod : 'init' } // TODO: remove elem field after enb-bem/enb-bem-techs#158
+    shouldDeps : { mod : 'init' }
 })

--- a/common.blocks/i-bem/__dom/i-bem__dom.deps.js
+++ b/common.blocks/i-bem/__dom/i-bem__dom.deps.js
@@ -4,7 +4,7 @@
         'objects',
         'functions',
         'dom',
-        { elem : 'dom', mod : 'init' }, // TODO: remove elem field after enb-bem/enb-bem-techs#158
+        { mod : 'init' },
         { block : 'i-bem', elems : ['internal'] }
     ]
 },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "enb-bem-techs": "^2.0.0",
     "enb-bem-docs": "0.8.1",
     "enb-bem-examples": "0.5.10",
-    "enb-bem-specs": "0.5.6",
+    "enb-bem-specs": "0.6.0",
     "enb-bem-tmpl-specs": "0.11.2",
     "enb-bemxjst": "1.3.4",
     "enb-bh": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "enb-bem-examples": "0.5.10",
     "enb-bem-specs": "0.6.0",
     "enb-bem-tmpl-specs": "0.13.2",
-    "enb-bemxjst": "1.3.4",
+    "enb-bemxjst": "2.0.0-rc",
     "enb-bh": "0.5.0",
     "enb-borschik": "^1.5.1",
     "enb-magic-platform": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "enb-bem-docs": "0.8.1",
     "enb-bem-examples": "0.5.10",
     "enb-bem-specs": "0.6.0",
-    "enb-bem-tmpl-specs": "0.11.2",
+    "enb-bem-tmpl-specs": "0.13.2",
     "enb-bemxjst": "1.3.4",
     "enb-bh": "0.5.0",
     "enb-borschik": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vow": "0.4.9",
     "reqf": "^1.0.0",
     "bem-naming": "0.5.1",
-    "enb": "0.15.0",
+    "enb": "^0.17.2",
     "enb-bem-techs": "^1.0.4",
     "enb-bem-docs": "0.8.0",
     "enb-bem-examples": "0.5.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "reqf": "^1.0.0",
     "bem-naming": "0.5.1",
     "enb": "^0.17.2",
-    "enb-bem-techs": "^1.0.4",
+    "enb-bem-techs": "^2.0.0",
     "enb-bem-docs": "0.8.0",
     "enb-bem-examples": "0.5.9",
     "enb-bem-specs": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "enb-bem-specs": "0.6.0",
     "enb-bem-tmpl-specs": "0.13.2",
     "enb-bemxjst": "2.0.0-rc",
-    "enb-bh": "0.5.0",
+    "enb-bh": "1.0.0-rc2",
     "enb-borschik": "2.0.0-beta1",
     "enb-magic-platform": "0.5.0",
     "enb-modules": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "enb-bem-tmpl-specs": "0.13.2",
     "enb-bemxjst": "2.0.0-rc",
     "enb-bh": "0.5.0",
-    "enb-borschik": "^1.5.1",
+    "enb-borschik": "2.0.0-beta1",
     "enb-magic-platform": "0.5.0",
     "enb-modules": "0.2.0",
     "borschik-tech-cleancss": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "enb": "^0.17.2",
     "enb-bem-techs": "^2.0.0",
     "enb-bem-docs": "0.8.1",
-    "enb-bem-examples": "0.5.9",
+    "enb-bem-examples": "0.5.10",
     "enb-bem-specs": "0.5.6",
     "enb-bem-tmpl-specs": "0.11.2",
     "enb-bemxjst": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bem-naming": "0.5.1",
     "enb": "^0.17.2",
     "enb-bem-techs": "^2.0.0",
-    "enb-bem-docs": "0.8.0",
+    "enb-bem-docs": "0.8.1",
     "enb-bem-examples": "0.5.9",
     "enb-bem-specs": "0.5.6",
     "enb-bem-tmpl-specs": "0.11.2",


### PR DESCRIPTION
Resolved #1124 

How the speed has changed is shown in table.

|  | Before | After |
| --- | --- | --- |
| dist | 9953ms | **8768ms** |
| specs | 29198ms | 29079ms |
| tmpl-specs | **2083ms** | 2468ms |
| docs | 3719ms | 3803ms |
| examples | 18134ms | **8833ms** |

**Conclusion**
- :rocket: accelerate the assembly of examples (`enb-bemxjst` is faster)
- :heavy_plus_sign: accelerate the assembly of dist (one BH-file less)
- :interrobang: slightly slowed down assembly of `tmpl-specs` (package itself)
