### PR TITLE
.bem/techs/browser.js.js: Use `.js` instead of `.browserjs` in `getCreateSuffixes`

### DIFF
--- a/.bem/techs/browser.js.js
+++ b/.bem/techs/browser.js.js
@@ -11,7 +11,7 @@ exports.techMixin = {
     },
 
     getCreateSuffixes : function() {
-        return ['browser.js'];
+        return ['js'];
     },
 
     getBuildSuffixes : function() {


### PR DESCRIPTION
close #1217
