### PR TITLE
DRAFT: mods()({ ... }) mode

### DIFF
--- a/common.blocks/i-bem/i-bem.bemhtml
+++ b/common.blocks/i-bem/i-bem.bemhtml
@@ -195,6 +195,11 @@ BEMContext.prototype.isShortTag = function isShortTag(t) {
     return SHORT_TAGS.hasOwnProperty(t);
 };
 
+BEMContext.prototype.mods = function(mods) {
+    this.ctx.mods = this.extend(this.ctx.mods || {}, mods);
+    return applyNext();
+};
+
 BEMContext.prototype.extend = function extend(o1, o2) {
     if(!o1 || !o2) return o1 || o2;
     var res = {}, n;


### PR DESCRIPTION
Хочу в BEMHTML.js вместо чего-то типа

``` js
def()(function(){
    this.ctx.mods = this.extend(this.ctx.mods || {}, { ... my mods ... });
    return applyNext();
})
```

писать так:
mods()({ ... my mods ... })

Как и куда это правильно запулреквестить?
