### PR TITLE
Use node.js 4 to run builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '0.12'
+  - '4'
 
 # sudo=false to run builds inside container infrastructure
 # see https://github.com/bem/bem-components/issues/1528


### PR DESCRIPTION
backport #1276 onto v2
