### PR TITLE
Improve use of buildClassName fn

### DIFF
--- a/common.blocks/i-bem-dom/i-bem-dom.js
+++ b/common.blocks/i-bem-dom/i-bem-dom.js
@@ -597,7 +597,7 @@ var BemDomEntity = inherit(/** @lends BemDomEntity.prototype */{
                         typeof entity.modVal === 'undefined'?
                             true :
                             entity.modVal) :
-                    buildClassName(entityName)) +
+                    entityName) +
                 (onlyFirst? ':first' : ''),
             domElems = this.domElem[select](selector);
 


### PR DESCRIPTION
Just a little improvement.
`buildClassName` has a lot of checks before it finally gets to case with only block variable.
It seems that we can omit `buildClassName` for such cases.

``` js
    buildClassName : function(block, elem, modName, modVal) {
        if(isSimple(modName)) {
            if(!isSimple(modVal)) {
                modVal = modName;
                modName = elem;
                elem = undef;
            }
        } else if(typeof modName !== 'undefined') {
            modName = undef;
        } else if(elem && typeof elem !== 'string') {
            elem = undef;
        }

        if(!(elem || modName)) { // optimization for simple case
            return block;
        }
        ...
```
