### PR TITLE
declMod with mixins

### DIFF
--- a/common.blocks/i-bem/i-bem.spec.js
+++ b/common.blocks/i-bem/i-bem.spec.js
@@ -230,6 +230,54 @@ describe('i-bem', function() {
         });
     });
 
+    describe('declMod with mixins', function() {
+        it('should contain methods from mod and mixin', function() {
+            var baseMethodSpy = sinon.spy(),
+                modsMethodSpy = sinon.spy(),
+                mixinMethodSpy = sinon.spy(),
+                Mixin = bem.declMixin({ mixinMethod : mixinMethodSpy }),
+                Block = bem
+                    .declBlock('block', { method : baseMethodSpy })
+                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : modsMethodSpy })
+                ,
+                instance = new Block({ mod : true });
+
+            // mod method
+            instance.method();
+            // Mixin-only method
+            instance.mixinMethod();
+
+            // Both methods must be called
+            modsMethodSpy.should.have.been.calledOnce;
+            mixinMethodSpy.should.have.been.calledOnce;
+
+            // Base method mustn't be called: `this.__base` not used
+            baseMethodSpy.should.not.have.been.called;
+
+        });
+
+        it('should inherit methods from mod and mixin', function() {
+            var baseMethodSpy = sinon.spy(),
+                modsMethodSpy = sinon.spy(),
+                mixinOverridedMethodSpy = sinon.spy(),
+                Mixin = bem.declMixin({ method : function(){ mixinOverridedMethodSpy(); this.__base(); } }),
+                Block = bem
+                    .declBlock('block', { method : baseMethodSpy })
+                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : function(){ modsMethodSpy(); this.__base(); } })
+                ,
+                instance = new Block({ mod : true });
+
+            // Common method
+            instance.method();
+
+            // All methods must be called
+            modsMethodSpy.should.have.been.calledOnce;
+            mixinOverridedMethodSpy.should.have.been.calledOnce;
+            baseMethodSpy.should.have.been.calledOnce;
+
+        });
+    });
+
     describe('create', function() {
         it('should return instance of block', function() {
             var Block = bem.declBlock('block', {}),

--- a/common.blocks/i-bem/i-bem.spec.js
+++ b/common.blocks/i-bem/i-bem.spec.js
@@ -274,6 +274,26 @@ describe('i-bem', function() {
             baseMethodSpy.should.have.been.calledOnce;
 
         });
+
+        it('should process several mixins', function() {
+            var mixin1MethodSpy = sinon.spy(),
+                mixin2MethodSpy = sinon.spy(),
+                Mixin1 = bem.declMixin({ mixin1Method : mixin1MethodSpy }),
+                Mixin2 = bem.declMixin({ mixin2Method : mixin2MethodSpy }),
+                Block = bem
+                    .declBlock('block')
+                    .declMod({ modName : 'mod', modVal : true }, [Mixin1, Mixin2]),
+                instance = new Block({ mod : true });
+
+            // Mixin' methods
+            instance.mixin1Method();
+            instance.mixin2Method();
+
+            // Both methods must be called
+            mixin1MethodSpy.should.have.been.calledOnce;
+            mixin2MethodSpy.should.have.been.calledOnce;
+
+        });
     });
 
     describe('create', function() {

--- a/common.blocks/i-bem/i-bem.spec.js
+++ b/common.blocks/i-bem/i-bem.spec.js
@@ -238,8 +238,7 @@ describe('i-bem', function() {
                 Mixin = bem.declMixin({ mixinMethod : mixinMethodSpy }),
                 Block = bem
                     .declBlock('block', { method : baseMethodSpy })
-                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : modsMethodSpy })
-                ,
+                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : modsMethodSpy }),
                 instance = new Block({ mod : true });
 
             // mod method
@@ -263,8 +262,7 @@ describe('i-bem', function() {
                 Mixin = bem.declMixin({ method : function(){ mixinOverridedMethodSpy(); this.__base(); } }),
                 Block = bem
                     .declBlock('block', { method : baseMethodSpy })
-                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : function(){ modsMethodSpy(); this.__base(); } })
-                ,
+                    .declMod({ modName : 'mod', modVal : true }, Mixin, { method : function(){ modsMethodSpy(); this.__base(); } }),
                 instance = new Block({ mod : true });
 
             // Common method

--- a/common.blocks/i-bem/i-bem.vanilla.js
+++ b/common.blocks/i-bem/i-bem.vanilla.js
@@ -467,13 +467,13 @@ var BemEntity = inherit(/** @lends BemEntity.prototype */ {
         });
 
         // If `base` is a list of mixins or single proto...
-        if ( Array.isArray(base) || typeof base === 'function' ) {
+        if(Array.isArray(base) || typeof base === 'function') {
             // ...Prepending main prototype to list
             base = [this].concat(base);
         }
         // ...Unexpected `base`...
-        else if ( base ) {
-            throw new Error ('`Base` must be prototype or list of prototypes ({Function|Array[Function]})');
+        else if(base) {
+            throw new Error('Mixin parameter `base` must be prototype or list of prototypes: `{Function|Array[Function]}`');
         }
         // No `base`...
         else {


### PR DESCRIPTION
Extended i-bem `declMod` method for correct passing mixins to `inherit`.

Example:
```javascript
Block.declMod({ modName : 'mod', modVal : true }, SomeMixin, /*...*/);
Block.declMod({ modName : 'mod', modVal : true }, [ SomeMixin, SomeMixin2 ], /*...*/);
```
See bem-forum issue: [Примешивание миксина к модификатору · Issue #1481 · bem-site/bem-forum-content-ru](https://github.com/bem-site/bem-forum-content-ru/issues/1481).