### PR TITLE
Deps: enb-bemxjst fixed and updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "enb-bem-specs": "^0.9.0",
     "enb-bem-techs": "^2.1.0",
     "enb-bem-tmpl-specs": "^1.1.0",
-    "enb-bemxjst": "8.6.7",
+    "enb-bemxjst": "^8.10.2",
     "enb-bemxjst-6x": "^6.5.3",
     "enb-bemxjst-7x": "^7.3.1",
     "enb-bemxjst-i18n": "1.0.0-beta3",


### PR DESCRIPTION
1) `options.requires` as fallback for `options.engineOptions.requires`
2) global dependencies with dot notation (`'BEM.I18N'` for example)